### PR TITLE
Prettier and ESLint Configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "recommendations": [
         "dbaeumer.vscode-eslint",
         "eamodio.tsl-problem-matcher",
-        "kieler.klighd-vscode"
+        "kieler.klighd-vscode",
+        "esbenp.prettier-vscode"
     ]
 }

--- a/keith-vscode/.eslintrc.js
+++ b/keith-vscode/.eslintrc.js
@@ -14,6 +14,15 @@ module.exports = {
         'prettier/prettier': 2, // Means error
         'import/extensions': [0, 'never'],
         'no-plusplus': 0,
+        'import/prefer-default-export': 0,
+        'no-useless-constructor': 0,
+        'no-restricted-syntax': 1,
+        'max-classes-per-file': 0,
+        'no-use-before-define': 0,
+        'no-underscore-dangle': 0,
+        'no-nested-ternary': 0,
+        'no-param-reassign': 0,
+        'class-methods-use-this': 0,
     },
     settings: {
         'import/resolver': {

--- a/keith-vscode/.eslintrc.js
+++ b/keith-vscode/.eslintrc.js
@@ -1,0 +1,26 @@
+module.exports = {
+    env: {
+        node: true,
+        es2021: true,
+    },
+    extends: ['airbnb-base', 'prettier', 'plugin:@typescript-eslint/recommended'],
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        ecmaVersion: 13,
+        sourceType: 'module',
+    },
+    plugins: ['@typescript-eslint', 'prettier', 'import'],
+    rules: {
+        'prettier/prettier': 2, // Means error
+        'import/extensions': [0, 'never'],
+        'no-plusplus': 0,
+    },
+    settings: {
+        'import/resolver': {
+            node: {
+                extensions: ['.js', '.jsx', '.ts', '.tsx'],
+            },
+        },
+        'import/core-modules': ['vscode'],
+    },
+}

--- a/keith-vscode/.prettierrc
+++ b/keith-vscode/.prettierrc
@@ -1,0 +1,8 @@
+{
+    "semi": false,
+    "singleQuote": true,
+    "trailingComma": "es5",
+    "useTabs": false,
+    "tabWidth": 4,
+    "printWidth": 120
+}

--- a/keith-vscode/package.json
+++ b/keith-vscode/package.json
@@ -4,7 +4,7 @@
   "description": "KIEL Environment Integrated in Visual Studio Code",
   "version": "0.1.0",
   "publisher": "kieler",
-  "author": "Kiel University \u003crt-kieler-devel@informatik.uni-kiel.de\u003e",
+  "author": "Kiel University <rt-kieler-devel@informatik.uni-kiel.de>",
   "icon": "icon.png",
   "license": "EPL-2.0",
   "repository": {
@@ -279,7 +279,8 @@
         "command": "keith-vscode.simulation-load-trace",
         "title": "Load trace",
         "category": "Simulation"
-      }, {
+      },
+      {
         "command": "keith-vscode.diplay-in-out",
         "title": "Set display in/out to ...",
         "category": "Simulation"
@@ -396,31 +397,31 @@
       ],
       "editor/title": [
         {
-          "when": "resourceLangId \u003d\u003d sctx || resourceLangId \u003d\u003d elkt || resourceLangId \u003d\u003d kgt || resourceLangId \u003d\u003d kviz || resourceLangId \u003d\u003d strl || resourceLangId \u003d\u003d lus",
+          "when": "resourceLangId == sctx || resourceLangId == elkt || resourceLangId == kgt || resourceLangId == kviz || resourceLangId == strl || resourceLangId == lus",
           "command": "keith-vscode.compile",
           "group": "navigation@1"
         },
         {
-          "when": "resourceLangId \u003d\u003d sctx || resourceLangId \u003d\u003d elkt || resourceLangId \u003d\u003d kgt || resourceLangId \u003d\u003d kviz || resourceLangId \u003d\u003d strl || resourceLangId \u003d\u003d lus",
+          "when": "resourceLangId == sctx || resourceLangId == elkt || resourceLangId == kgt || resourceLangId == kviz || resourceLangId == strl || resourceLangId == lus",
           "command": "keith-vscode.simulate",
           "group": "navigation@2"
         },
         {
-          "when": "resourceLangId \u003d\u003d sctx || resourceLangId \u003d\u003d elkt || resourceLangId \u003d\u003d kgt || resourceLangId \u003d\u003d kviz || resourceLangId \u003d\u003d strl || resourceLangId \u003d\u003d lus",
+          "when": "resourceLangId == sctx || resourceLangId == elkt || resourceLangId == kgt || resourceLangId == kviz || resourceLangId == strl || resourceLangId == lus",
           "command": "klighd-vscode.diagram.open",
           "group": "navigation@300000"
         }
       ],
       "editor/context": [
         {
-          "when": "resourceLangId \u003d\u003d sctx || resourceLangId \u003d\u003d elkt || resourceLangId \u003d\u003d kgt || resourceLangId \u003d\u003d kviz || resourceLangId \u003d\u003d strl || resourceLangId \u003d\u003d lus",
+          "when": "resourceLangId == sctx || resourceLangId == elkt || resourceLangId == kgt || resourceLangId == kviz || resourceLangId == strl || resourceLangId == lus",
           "command": "klighd-vscode.diagram.open",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
-          "when": "resourceLangId \u003d\u003d sctx || resourceLangId \u003d\u003d elkt || resourceLangId \u003d\u003d kgt || resourceLangId \u003d\u003d kviz || resourceLangId \u003d\u003d strl || resourceLangId \u003d\u003d lus",
+          "when": "resourceLangId == sctx || resourceLangId == elkt || resourceLangId == kgt || resourceLangId == kviz || resourceLangId == strl || resourceLangId == lus",
           "command": "klighd-vscode.diagram.open",
           "group": "navigation"
         }
@@ -464,23 +465,23 @@
       ]
     },
     "viewsContainers": {
-        "activitybar": [
-            {
-                "id": "kieler",
-                "title": "KIELER",
-                "icon": "./icon.png"
-            }
-        ]
+      "activitybar": [
+        {
+          "id": "kieler",
+          "title": "KIELER",
+          "icon": "./icon.png"
+        }
+      ]
     },
     "views": {
       "kieler": [
         {
-            "type": "tree",
-            "id": "kieler-kico",
-            "name": "KIELER Compiler"
+          "type": "tree",
+          "id": "kieler-kico",
+          "name": "KIELER Compiler"
         },
         {
-					"type": "tree",
+          "type": "tree",
           "id": "kieler-simulation-tree",
           "name": "KIELER Simulation Tree"
         }
@@ -533,7 +534,11 @@
           "type": "string",
           "default": "Periodic",
           "description": "The currently selected simulation type.",
-          "enum": ["Periodic", "Manual", "Dynamic"]
+          "enum": [
+            "Periodic",
+            "Manual",
+            "Dynamic"
+          ]
         },
         "keith-vscode.showInternalVariables.enabled": {
           "type": "boolean",
@@ -555,12 +560,21 @@
     "vscode:prepublish": "yarn run build"
   },
   "devDependencies": {
-    "@types/vscode": "^1.56.0",
     "@types/node": "^12.11.7",
     "@types/react": "^17.0.27",
+    "@types/vscode": "^1.56.0",
+    "@typescript-eslint/eslint-plugin": "^5.5.0",
+    "@typescript-eslint/parser": "^5.5.0",
     "clean-webpack-plugin": "^4.0.0-alpha.0",
     "css-loader": "^5.2.4",
+    "eslint": "^8.4.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-import-resolver-typescript": "^2.5.0",
+    "eslint-plugin-import": "^2.25.3",
+    "eslint-plugin-prettier": "^4.0.0",
     "mini-css-extract-plugin": "^1.6.0",
+    "prettier": "2.5.1",
     "ts-loader": "^9.2.3",
     "vsce": "1.88.0",
     "webpack": "^5.39.1",
@@ -571,7 +585,7 @@
     "react": "^17.0.2",
     "snabbdom-jsx": "^0.4.2",
     "snabbdom-to-html": "^7.0.0",
-    "vscode-uri": "^3.0.2",
-    "vscode-languageclient": "^5.2.1"
+    "vscode-languageclient": "^5.2.1",
+    "vscode-uri": "^3.0.2"
   }
 }

--- a/keith-vscode/src/constants.ts
+++ b/keith-vscode/src/constants.ts
@@ -1,8 +1,8 @@
-export const extensionName = 'kieler';
+export const extensionName = 'kieler'
 
 /**
  * Object holding all information about the views of this extension.
- * view.id has to be the same as specified in package.json. 
+ * view.id has to be the same as specified in package.json.
  */
 export const views = {
     compiler: {
@@ -13,35 +13,34 @@ export const views = {
         id: 'kieler-simulation-tree',
         name: 'KIELER Simulation Tree',
     },
-};
+}
 
 /**
  * Key, under which the settings for this extension are accessible.
  */
-export const settingsKey = 'keith-vscode';
+export const settingsKey = 'keith-vscode'
 
-
-export type SimulationType = 'Manual' | 'Periodic' |  'Dynamic';
+export type SimulationType = 'Manual' | 'Periodic' | 'Dynamic'
 
 /**
  * Keys for all settings under the 'keith-vscode' namespace with their corresponding type.
  */
 export type Settings = {
-    'autocompile.enabled': boolean;
-    'compileInplace.enabled': boolean;
-    'showResultingModel.enabled': boolean;
-    'showButtons.enabled': boolean;
-    'showPrivateSystems.enabled': boolean;
+    'autocompile.enabled': boolean
+    'compileInplace.enabled': boolean
+    'showResultingModel.enabled': boolean
+    'showButtons.enabled': boolean
+    'showPrivateSystems.enabled': boolean
     /**
      * Time in milliseconds to wait till next simulation step is requested in play mode.
      */
-    'simulationStepDelay': number;
+    simulationStepDelay: number
     /**
      * The currently selected simulation type.
      */
-    'simulationType': SimulationType;
+    simulationType: SimulationType
     /**
      * Show internal variables of simulation (e.g. guards, ...).
      */
-    'showInternalVariables.enabled': boolean;
+    'showInternalVariables.enabled': boolean
 }

--- a/keith-vscode/src/error-handler.ts
+++ b/keith-vscode/src/error-handler.ts
@@ -11,13 +11,8 @@
  * This code is provided under the terms of the Eclipse Public License (EPL).
  */
 
-import { window } from "vscode";
-import {
-    CloseAction,
-    ErrorAction,
-    ErrorHandler,
-    Message,
-} from "vscode-languageclient";
+import { window } from 'vscode'
+import { CloseAction, ErrorAction, ErrorHandler, Message } from 'vscode-languageclient'
 
 /**
  * Simple LS connection error handling that informs the user about encountered
@@ -27,15 +22,15 @@ export class KeithErrorHandler implements ErrorHandler {
     constructor(private defaultHandler: ErrorHandler) {}
 
     error(error: Error, message: Message, count: number): ErrorAction {
-        window.showErrorMessage("Connection to KIELER Language Server produced an error!");
-        console.error(error);
+        window.showErrorMessage('Connection to KIELER Language Server produced an error!')
+        console.error(error)
 
-        return this.defaultHandler.error(error, message, count);
+        return this.defaultHandler.error(error, message, count)
     }
 
     closed(): CloseAction {
-        window.showErrorMessage("Connection to KIELER Language Server got closed!");
+        window.showErrorMessage('Connection to KIELER Language Server got closed!')
 
-        return this.defaultHandler.closed();
+        return this.defaultHandler.closed()
     }
 }

--- a/keith-vscode/src/extension.ts
+++ b/keith-vscode/src/extension.ts
@@ -11,104 +11,34 @@
  * This code is provided under the terms of the Eclipse Public License (EPL).
  */
 
-import * as vscode from "vscode";
-import {
-    LanguageClient,
-    ServerOptions,
-    LanguageClientOptions,
-    StreamInfo,
-} from "vscode-languageclient";
-import { connect, NetConnectOpts, Socket } from "net";
-import { KeithErrorHandler } from "./error-handler";
-import { performActionKind, handlePerformAction } from "./perform-action-handler";
-import { CompilationDataProvider } from "./kico/compilation-data-provider";
-import { SimulationTreeDataProvider } from "./simulation/simulation-tree-data-provider";
-import { SettingsService } from "./settings";
-import { Settings, settingsKey } from "./constants";
+import * as vscode from 'vscode'
+import { LanguageClient, ServerOptions, LanguageClientOptions, StreamInfo } from 'vscode-languageclient'
+import { connect, NetConnectOpts, Socket } from 'net'
+import { KeithErrorHandler } from './error-handler'
+import { performActionKind, handlePerformAction } from './perform-action-handler'
+import { CompilationDataProvider } from './kico/compilation-data-provider'
+import { SimulationTreeDataProvider } from './simulation/simulation-tree-data-provider'
+import { SettingsService } from './settings'
+import { Settings, settingsKey } from './constants'
 // import 'simulation/index.css'
 
-//** Command identifiers that are provided by klighd-vscode. */
+/** Command identifiers that are provided by klighd-vscode. */
 const klighdCommands = {
-    setLanguageClient: "klighd-vscode.setLanguageClient",
-    addActionHandler: "klighd-vscode.addActionHandler",
-    dispatchAction: "klighd-vscode.dispatchAction",
-};
+    setLanguageClient: 'klighd-vscode.setLanguageClient',
+    addActionHandler: 'klighd-vscode.addActionHandler',
+    dispatchAction: 'klighd-vscode.dispatchAction',
+}
 
 /**
  * All file endings of the languages that are supported by keith-vscode.
  * The file ending should also be the language id, since it is also used to
  * register document selectors in the language client.
  */
-const supportedFileEndings = ["sctx", "scl", "elkt", "kgt", "kviz", "strl", "lus"];
+const supportedFileEndings = ['sctx', 'scl', 'elkt', 'kgt', 'kviz', 'strl', 'lus']
 
-let lsClient: LanguageClient;
-let socket: Socket;
-let settingsService: SettingsService<Settings>;
-
-// this method is called when your extension is activated
-export async function activate(context: vscode.ExtensionContext): Promise<void> {
-    const serverOptions: ServerOptions = createServerOptions(context);
-
-    const clientOptions: LanguageClientOptions = {
-        documentSelector: supportedFileEndings.map((ending) => ({
-            scheme: "file",
-            language: ending,
-        })),
-        synchronize: {
-            fileEvents: vscode.workspace.createFileSystemWatcher("**/*.*"),
-        },
-    };
-
-    lsClient = new LanguageClient("KIELER Language Server", serverOptions, clientOptions, true);
-
-    // Setup basic connection error reporting
-    const defaultErrorHandler = lsClient.createDefaultErrorHandler();
-    lsClient.clientOptions.errorHandler = new KeithErrorHandler(defaultErrorHandler);
-
-    // Inform the KLighD extension about the LS client and supported file endings.
-    const refId = await vscode.commands.executeCommand<string>(
-        klighdCommands.setLanguageClient,
-        lsClient,
-        supportedFileEndings
-    );
-    // Intercept PerformActionActions from klighd diagrams.
-    vscode.commands.executeCommand(
-        klighdCommands.addActionHandler,
-        refId,
-        performActionKind,
-        handlePerformAction
-    );
-
-    // create SettingsService with list of setting-keys to manage                
-    settingsService = new SettingsService<Settings>(settingsKey, ['autocompile.enabled', 'compileInplace.enabled', 'showResultingModel.enabled', 'showButtons.enabled', 'showPrivateSystems.enabled', 'simulationStepDelay', 'simulationType', 'showInternalVariables.enabled']);
-
-    const compilationDataProvider = new CompilationDataProvider(lsClient, context, settingsService);
-
-    // Register and start kico view
-    vscode.window.registerTreeDataProvider(
-        'kieler-kico',
-        compilationDataProvider
-    );
-    vscode.window.createTreeView('kieler-kico', {
-        treeDataProvider: compilationDataProvider
-    });
-
-
-    const simulationTreeDataProvider = new SimulationTreeDataProvider(lsClient, compilationDataProvider, context, settingsService)
-    // Register and start simulation tree view
-    vscode.window.registerTreeDataProvider(
-        'kieler-simulation-tree',
-        simulationTreeDataProvider
-    );
-    vscode.window.createTreeView('kieler-simulation-tree', {
-        treeDataProvider: simulationTreeDataProvider
-    });
-
-    console.debug("Starting Language Server...");
-    lsClient.start();
-
-    // TODO save stuff in context e.g. commands.executeCommand("setContext", "var", value);
-}
+let lsClient: LanguageClient
+let socket: Socket
+let settingsService: SettingsService<Settings>
 
 // this method is called when your extension is deactivated
 export function deactivate(): Promise<void> {
@@ -116,11 +46,25 @@ export function deactivate(): Promise<void> {
         if (socket) {
             // Don't call lsClient.stop when we are connected via socket for development.
             // That call will end the LS server, leading to a bad dev experience.
-            socket.end(resolve);
-            return;
+            socket.end(resolve)
+            return
         }
-        lsClient?.stop().then(resolve);
-    });
+        lsClient?.stop().then(resolve)
+    })
+}
+
+/** Returns the codename used by KIELER for current OS plattform. */
+function getPlattformType(): 'linux' | 'win' | 'osx' {
+    switch (process.platform) {
+        case 'linux':
+            return 'linux'
+        case 'win32':
+            return 'win'
+        case 'darwin':
+            return 'osx'
+        default:
+            throw new Error(`Unknown plattform "${process.platform}".`)
+    }
 }
 
 /**
@@ -131,43 +75,93 @@ export function deactivate(): Promise<void> {
  */
 function createServerOptions(context: vscode.ExtensionContext): ServerOptions {
     // Connect to language server via socket if a port is specified as an env variable
-    if (typeof process.env.KEITH_LS_PORT !== "undefined") {
+    if (typeof process.env.KEITH_LS_PORT !== 'undefined') {
         const connectionInfo: NetConnectOpts = {
             port: parseInt(process.env.KEITH_LS_PORT, 10),
-        };
-        console.log("Connecting to language server on port: ", connectionInfo.port);
+        }
+        console.log('Connecting to language server on port: ', connectionInfo.port)
 
         return async () => {
-            socket = connect(connectionInfo);
+            socket = connect(connectionInfo)
             const result: StreamInfo = {
                 writer: socket,
                 reader: socket,
-            };
-            return result;
-        };
-    } else {
-        console.log("Spawning the language server as a process.");
-        const lsPath = context.asAbsolutePath(
-            `server/kieler-language-server.${getPlattformType()}.jar`
-        );
+            }
+            return result
+        }
+    }
+    console.log('Spawning the language server as a process.')
+    const lsPath = context.asAbsolutePath(`server/kieler-language-server.${getPlattformType()}.jar`)
 
-        return {
-            run: { command: "java", args: ["-jar", lsPath] },
-            debug: { command: "java", args: ["-jar", lsPath] },
-        };
+    return {
+        run: { command: 'java', args: ['-jar', lsPath] },
+        debug: { command: 'java', args: ['-jar', lsPath] },
     }
 }
 
-/** Returns the codename used by KIELER for current OS plattform. */
-function getPlattformType(): "linux" | "win" | "osx" {
-    switch (process.platform) {
-        case "linux":
-            return "linux";
-        case "win32":
-            return "win";
-        case "darwin":
-            return "osx";
-        default:
-            throw new Error(`Unknown plattform "${process.platform}".`);
+// this method is called when your extension is activated
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    const serverOptions: ServerOptions = createServerOptions(context)
+
+    const clientOptions: LanguageClientOptions = {
+        documentSelector: supportedFileEndings.map((ending) => ({
+            scheme: 'file',
+            language: ending,
+        })),
+        synchronize: {
+            fileEvents: vscode.workspace.createFileSystemWatcher('**/*.*'),
+        },
     }
+
+    lsClient = new LanguageClient('KIELER Language Server', serverOptions, clientOptions, true)
+
+    // Setup basic connection error reporting
+    const defaultErrorHandler = lsClient.createDefaultErrorHandler()
+    lsClient.clientOptions.errorHandler = new KeithErrorHandler(defaultErrorHandler)
+
+    // Inform the KLighD extension about the LS client and supported file endings.
+    const refId = await vscode.commands.executeCommand<string>(
+        klighdCommands.setLanguageClient,
+        lsClient,
+        supportedFileEndings
+    )
+    // Intercept PerformActionActions from klighd diagrams.
+    vscode.commands.executeCommand(klighdCommands.addActionHandler, refId, performActionKind, handlePerformAction)
+
+    // create SettingsService with list of setting-keys to manage
+    settingsService = new SettingsService<Settings>(settingsKey, [
+        'autocompile.enabled',
+        'compileInplace.enabled',
+        'showResultingModel.enabled',
+        'showButtons.enabled',
+        'showPrivateSystems.enabled',
+        'simulationStepDelay',
+        'simulationType',
+        'showInternalVariables.enabled',
+    ])
+
+    const compilationDataProvider = new CompilationDataProvider(lsClient, context, settingsService)
+
+    // Register and start kico view
+    vscode.window.registerTreeDataProvider('kieler-kico', compilationDataProvider)
+    vscode.window.createTreeView('kieler-kico', {
+        treeDataProvider: compilationDataProvider,
+    })
+
+    const simulationTreeDataProvider = new SimulationTreeDataProvider(
+        lsClient,
+        compilationDataProvider,
+        context,
+        settingsService
+    )
+    // Register and start simulation tree view
+    vscode.window.registerTreeDataProvider('kieler-simulation-tree', simulationTreeDataProvider)
+    vscode.window.createTreeView('kieler-simulation-tree', {
+        treeDataProvider: simulationTreeDataProvider,
+    })
+
+    console.debug('Starting Language Server...')
+    lsClient.start()
+
+    // TODO save stuff in context e.g. commands.executeCommand("setContext", "var", value);
 }

--- a/keith-vscode/src/kico/commands.ts
+++ b/keith-vscode/src/kico/commands.ts
@@ -10,43 +10,43 @@
  *
  * This code is provided under the terms of the Eclipse Public License (EPL).
  */
-import * as vscode from 'vscode';
-import { extensionName, views } from '../constants';
+import * as vscode from 'vscode'
+import { extensionName, views } from '../constants'
 
 export const SHOW_COMMAND: vscode.Command = {
     command: 'keith-vscode.show',
-    title: 'Show Snapshot'
+    title: 'Show Snapshot',
 }
 
 export const COMPILE_COMMAND: vscode.Command = {
     command: 'keith-vscode.compile',
-    title: 'Compile'
+    title: 'Compile',
 }
 
 export const COMPILE_SNAPSHOT_COMMAND: vscode.Command = {
     command: 'keith-vscode.compile-snapshot',
-    title: 'Compile model in diagram'
+    title: 'Compile model in diagram',
 }
 
 export const SHOW_NEXT: vscode.Command = {
     command: 'keith-vscode.show-next',
-    title: 'Show next'
+    title: 'Show next',
 }
 export const SHOW_PREVIOUS: vscode.Command = {
     command: 'keith-vscode.show-previous',
-    title: 'Show previous'
+    title: 'Show previous',
 }
 export const COMPILER: vscode.Command = {
     command: 'kico-compiler:toggle',
-    title: 'Kico: Compiler'
+    title: 'Kico: Compiler',
 }
 export const REQUEST_CS: vscode.Command = {
     command: 'keith-vscode.request-compilation-systems',
-    title: 'Request compilation systems'
+    title: 'Request compilation systems',
 }
 export const TOGGLE_INPLACE: vscode.Command = {
     command: 'keith-vscode.inplace',
-    title: 'Toggle inplace compilation'
+    title: 'Toggle inplace compilation',
 }
 /**
  * Show the resulting model after compile.
@@ -54,22 +54,21 @@ export const TOGGLE_INPLACE: vscode.Command = {
  */
 export const TOGGLE_SHOW_RESULTING_MODEL: vscode.Command = {
     command: 'keith-vscode.show-resulting-model',
-    title: 'Toggle show model after compile'
+    title: 'Toggle show model after compile',
 }
 export const TOGGLE_PRIVATE_SYSTEMS: vscode.Command = {
     command: 'keith-vscode.show-private-systems',
-    title: 'Toggle show private systems'
+    title: 'Toggle show private systems',
 }
 export const TOGGLE_AUTO_COMPILE: vscode.Command = {
     command: 'keith-vscode.auto-compile',
-    title: 'Toggle auto compile'
-};
+    title: 'Toggle auto compile',
+}
 
 export const TOGGLE_BUTTON_MODE: vscode.Command = {
     command: 'keith-vscode.button-mode',
-    title: 'Toggle button mode'
+    title: 'Toggle button mode',
 }
-
 
 /**
  * Utility commands for focussing different views of the extension.
@@ -78,15 +77,15 @@ export const TOGGLE_BUTTON_MODE: vscode.Command = {
 
 export const REVEAL_COMPILATION_WIDGET: vscode.Command = {
     command: `${views.compiler.id}.focus`,
-    title: `Focus on ${views.compiler.name} View`
+    title: `Focus on ${views.compiler.name} View`,
 }
 
 export const REVEAL_SIMULATION_WIDGET: vscode.Command = {
     command: `${views.simulation.id}.focus`,
-    title: `Focus on ${views.simulation.name} View`
+    title: `Focus on ${views.simulation.name} View`,
 }
 
 export const OPEN_KIELER_VIEW: vscode.Command = {
     command: `workbench.view.extension.${extensionName}`,
-    title: 'Show KIELER'
+    title: 'Show KIELER',
 }

--- a/keith-vscode/src/kico/style/index.css
+++ b/keith-vscode/src/kico/style/index.css
@@ -12,7 +12,8 @@
     margin-right: 30px;
 }
 
-button, .show-button {
+button,
+.show-button {
     display: inline-block;
     border: none;
     color: var(--theia-button-foreground);
@@ -25,11 +26,13 @@ button, .show-button {
     padding-right: 2px;
     padding-top: 2px;
     padding-bottom: 2px;
-    margin-left: calc(var(--theia-ui-padding)*2);
+    margin-left: calc(var(--theia-ui-padding) * 2);
     margin-top: 12px;
     border-radius: 1px;
-    box-shadow: 0px 1px 5px 0px var(--theia-checkbox-border), 0px 1px 2px 0px var(--theia-checkbox-border), 0px 1px 1px -2px var(--theia-checkbox-border);
-    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    box-shadow: 0px 1px 5px 0px var(--theia-checkbox-border), 0px 1px 2px 0px var(--theia-checkbox-border),
+        0px 1px 1px -2px var(--theia-checkbox-border);
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
+        box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     width: auto;
     /* border-width: medium;    
     border-style: solid; */
@@ -48,7 +51,7 @@ button, .show-button {
     color: var(--theia-button-foreground);
 }
 .compiler-widget {
-	font-size: var(--theia-ui-font-size1);
+    font-size: var(--theia-ui-font-size1);
     color: var(--theia-foreground);
     display: grid;
     grid-auto-rows: min-content;
@@ -57,7 +60,7 @@ button, .show-button {
 .compilation-panel {
     margin-top: 12px;
     display: flex;
-    margin-left: calc(var(--theia-ui-padding)*2);
+    margin-left: calc(var(--theia-ui-padding) * 2);
 }
 
 .selection-list {
@@ -72,7 +75,8 @@ button, .show-button {
     margin-right: 1px;
     -webkit-appearance: none;
     -moz-appearance: none;
-    background-image: linear-gradient(45deg, transparent 50%, var(--theia-dropdown-border) 50%), linear-gradient(135deg, var(--theia-dropdown-border) 50%, transparent 50%);
+    background-image: linear-gradient(45deg, transparent 50%, var(--theia-dropdown-border) 50%),
+        linear-gradient(135deg, var(--theia-dropdown-border) 50%, transparent 50%);
     background-position: calc(100% - 6px) 8px, calc(100% - 2px) 8px, 100% 0;
     background-size: 4px 5px;
     background-repeat: no-repeat;
@@ -89,8 +93,10 @@ button, .show-button {
     border-radius: 0;
     outline: none;
     cursor: pointer;
-    box-shadow: 0px 1px 5px 0px var(--theia-checkbox-border), 0px 1px 2px 0px var(--theia-checkbox-border), 0px 1px 1px -2px var(--theia-checkbox-border);
-    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    box-shadow: 0px 1px 5px 0px var(--theia-checkbox-border), 0px 1px 2px 0px var(--theia-checkbox-border),
+        0px 1px 1px -2px var(--theia-checkbox-border);
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
+        box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     display: inline-block;
     text-align: center;
     vertical-align: middle;
@@ -110,8 +116,10 @@ button, .show-button {
     border-radius: 0;
     outline: none;
     cursor: pointer;
-    box-shadow: 0px 1px 5px 0px var(--theia-checkbox-border), 0px 1px 2px 0px var(--theia-checkbox-border), 0px 1px 1px -2px var(--theia-checkbox-border);
-    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    box-shadow: 0px 1px 5px 0px var(--theia-checkbox-border), 0px 1px 2px 0px var(--theia-checkbox-border),
+        0px 1px 1px -2px var(--theia-checkbox-border);
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
+        box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     display: inline-block;
     text-align: center;
     vertical-align: middle;
@@ -157,7 +165,7 @@ button, .show-button {
 }
 
 .buttonContainer {
-    display: inline-block
+    display: inline-block;
 }
 
 .snapshot-list {

--- a/keith-vscode/src/perform-action-handler.ts
+++ b/keith-vscode/src/perform-action-handler.ts
@@ -11,47 +11,46 @@
  * This code is provided under the terms of the Eclipse Public License (EPL).
  */
 
-import * as vscode from "vscode";
-import { ADD_CO_SIMULATION, SIMULATE } from "./simulation/commands";
+import * as vscode from 'vscode'
+import { ADD_CO_SIMULATION, SIMULATE } from './simulation/commands'
 
 // Take a look at the `klighd-vscode` extension for more documentation about action
 // handlers.
 
 // Action IDs defined by KLighD
-const openInEditorId =
-    "de.cau.cs.kieler.kicool.ui.klighd.internal.model.action.OpenCodeInEditorAction";
-const startSimulationId = "de.cau.cs.kieler.simulation.ui.synthesis.action.StartSimulationAction";
-const addCoSimulationId = "de.cau.cs.kieler.simulation.ui.synthesis.action.AddCoSimulationAction";
+const openInEditorId = 'de.cau.cs.kieler.kicool.ui.klighd.internal.model.action.OpenCodeInEditorAction'
+const startSimulationId = 'de.cau.cs.kieler.simulation.ui.synthesis.action.StartSimulationAction'
+const addCoSimulationId = 'de.cau.cs.kieler.simulation.ui.synthesis.action.AddCoSimulationAction'
 
 /** Shape of the `PerformActionAction` object that is sent to LS by `klighd-vscode`. */
 export interface PerformActionAction {
-    kind: "performAction";
-    actionId: string;
+    kind: 'performAction'
+    actionId: string
 }
 
 /** Action kind that should be intercepted by {@link handlePerformAction}. */
-export const performActionKind = "performAction";
+export const performActionKind = 'performAction'
 
 /**
  * Action handler that is registered in `klighd-diagram` to catch and handle {@link PerformActionAction}.
  */
 export async function handlePerformAction(action: PerformActionAction): Promise<boolean> {
-    if (action.kind !== performActionKind) return true;
+    if (action.kind !== performActionKind) return true
 
     switch (action.actionId) {
         case openInEditorId:
             // TODO
-            vscode.window.showInformationMessage("Triggered perform action to open in editor.");
-            return false;
+            vscode.window.showInformationMessage('Triggered perform action to open in editor.')
+            return false
         case startSimulationId:
             // TODO needs to be tested
             vscode.commands.executeCommand(SIMULATE.command)
-            return false;
+            return false
         case addCoSimulationId:
             // TODO needs to be tested
             vscode.commands.executeCommand(ADD_CO_SIMULATION.command)
-            return false;
+            return false
         default:
-            return true;
+            return true
     }
 }

--- a/keith-vscode/src/settings.ts
+++ b/keith-vscode/src/settings.ts
@@ -1,46 +1,58 @@
-import * as vscode from 'vscode';
-import { Tuple } from './util';
-  
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ *
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ *
+ * This code is provided under the terms of the Eclipse Public License (EPL).
+ */
+
+import * as vscode from 'vscode'
+import { Tuple } from './util'
+
 /**
  * Type for enforcing list of settings.
  */
-type SettingList<S> = Tuple<Extract<keyof S, string>>;
+type SettingList<S> = Tuple<Extract<keyof S, string>>
 
 /**
  * Service for providing an interface for retrieving and updating VSC settings.
  */
 export class SettingsService<S> {
-
     /**
      * Cache for settings, so no calls to API are needed upon requests for values of settings.
      */
-    private readonly cache: Map<string, any>;
+    private readonly cache: Map<string, any>
 
     /**
      * Initialize a new wrapper around the settings API of VSC for a specific configuration with built-in caching.
-     * 
+     *
      * @param configurationKey key ('namespace') of the configuration. Supports dot-notation
-     * @param settingKeys list of settings to manage. Note: This HAS to be an array containing 
+     * @param settingKeys list of settings to manage. Note: This HAS to be an array containing
      *                    the keys of all settings passed as the class generic.
      */
     constructor(private readonly configurationKey: string, settingKeys: SettingList<S>) {
-        this.cache = new Map();
-        
+        this.cache = new Map()
+
         // read current settings into cache
-        const configuration = vscode.workspace.getConfiguration(configurationKey);
+        const configuration = vscode.workspace.getConfiguration(configurationKey)
         for (const key of settingKeys as string[]) {
-            this.cache.set(key, configuration.get(key));
+            this.cache.set(key, configuration.get(key))
         }
-        
+
         // register listener for setting changes
-        vscode.workspace.onDidChangeConfiguration(e => {
+        vscode.workspace.onDidChangeConfiguration((e) => {
             // get current workspace configuration and iterate over current cache
-            const configuration = vscode.workspace.getConfiguration(this.configurationKey);
+            const config = vscode.workspace.getConfiguration(this.configurationKey)
             for (const key of this.cache.keys()) {
                 // update cache, if settings are changed
-                const setting = `${this.configurationKey}`;
+                const setting = `${this.configurationKey}`
                 if (e.affectsConfiguration(setting)) {
-                    this.cache.set(key, configuration.get(key));
+                    this.cache.set(key, config.get(key))
                 }
             }
         })
@@ -48,23 +60,23 @@ export class SettingsService<S> {
 
     /**
      * Get the value of a setting from VSC.
-     * 
+     *
      * @param key key of the setting to get
      * @returns current value of the setting
      */
     public get<K extends Extract<keyof S, string>>(key: K): S[K] {
-        return this.cache.get(key);
+        return this.cache.get(key)
     }
 
     /**
      * Set the value of a setting in VSC.
-     * 
+     *
      * @param key key of the setting
      * @param value new value of the setting
      */
     public set<K extends Extract<keyof S, string>>(key: K, value: S[K]): void {
-        const configurationTarget = this.determineConfigurationTarget(key);
-        vscode.workspace.getConfiguration(this.configurationKey).update(key, value, configurationTarget);
+        const configurationTarget = this.determineConfigurationTarget(key)
+        vscode.workspace.getConfiguration(this.configurationKey).update(key, value, configurationTarget)
     }
 
     /**
@@ -73,18 +85,18 @@ export class SettingsService<S> {
      *  - {@link vscode.ConfigurationTarget.WorkspaceFolder}, if there is configuration in one of the current workspace folders
      *  - {@link vscode.ConfigurationTarget.Workspace}, if there is a configuration in the current workspace
      *  - {@link vscode.ConfigurationTarget.Global} otherwise
-     *    
+     *
      * @param key key of the configuration
      * @returns the determined {@link vscode.ConfigurationTarget}
      */
     private determineConfigurationTarget<K extends Extract<keyof S, string>>(key: K): vscode.ConfigurationTarget {
-        const inspection = vscode.workspace.getConfiguration(this.configurationKey).inspect(key);
-        let configurationTarget: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global;
+        const inspection = vscode.workspace.getConfiguration(this.configurationKey).inspect(key)
+        let configurationTarget: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global
         if (inspection?.workspaceFolderValue !== undefined) {
-            configurationTarget = vscode.ConfigurationTarget.WorkspaceFolder;
+            configurationTarget = vscode.ConfigurationTarget.WorkspaceFolder
         } else if (inspection?.workspaceValue !== undefined) {
-            configurationTarget = vscode.ConfigurationTarget.Workspace;
+            configurationTarget = vscode.ConfigurationTarget.Workspace
         }
-        return configurationTarget;
+        return configurationTarget
     }
 }

--- a/keith-vscode/src/simulation/commands.ts
+++ b/keith-vscode/src/simulation/commands.ts
@@ -10,106 +10,106 @@
  *
  * This code is provided under the terms of the Eclipse Public License (EPL).
  */
-import * as vscode from 'vscode';
+import * as vscode from 'vscode'
 /**
  * Command to restart a simulation.
  */
- export const SIMULATE: vscode.Command = {
+export const SIMULATE: vscode.Command = {
     command: 'keith-vscode.simulation-restart',
-    title: 'Restart simulation'
+    title: 'Restart simulation',
 }
 
 export const COMPILE_AND_SIMULATE: vscode.Command = {
     command: 'keith-vscode.simulate',
-    title: 'Simulate'
+    title: 'Simulate',
 }
 
 export const COMPILE_AND_SIMULATE_SNAPSHOT: vscode.Command = {
     command: 'keith-vscode.simulate-snapshot',
-    title: 'Simulate snapshot'
+    title: 'Simulate snapshot',
 }
 
 export const STOP_SIMULATION: vscode.Command = {
     command: 'keith-vscode.simulation-stop',
-    title: 'Stop simulation'
+    title: 'Stop simulation',
 }
 
 export const STEP_SIMULATION: vscode.Command = {
     command: 'keith-vscode.simulation-step',
-    title: 'Execute simulation step'
+    title: 'Execute simulation step',
 }
 
 export const PAUSE_SIMULATION: vscode.Command = {
     command: 'keith-vscode.simulation-pause',
-    title: 'Pause simulation'
+    title: 'Pause simulation',
 }
 
 export const RUN_SIMULATION: vscode.Command = {
     command: 'keith-vscode.simulation-run',
-    title: 'Run simulation'
+    title: 'Run simulation',
 }
 
 export const SAVE_TRACE: vscode.Command = {
     command: 'keith-vscode.simulation-save-trace',
-    title: 'Save trace'
+    title: 'Save trace',
 }
 
 export const LOAD_TRACE: vscode.Command = {
     command: 'keith-vscode.simulation-load-trace',
-    title: 'Load trace'
+    title: 'Load trace',
 }
 
 export const NEW_VALUE_SIMULATION: vscode.Command = {
     command: 'keith-vscode.simulation-new-value',
-    title: 'New value for ...'
+    title: 'New value for ...',
 }
 
 export const OPEN_INTERNAL_KVIZ_VIEW: vscode.Command = {
     command: 'keith-vscode.open-kviz-internal',
-    title: 'Open KViz view in internal browser preview'
+    title: 'Open KViz view in internal browser preview',
 }
 
 export const OPEN_EXTERNAL_KVIZ_VIEW: vscode.Command = {
     command: 'keith-vscode.open-kviz-external',
-    title: 'Open KViz view in external browser'
+    title: 'Open KViz view in external browser',
 }
 
 export const ADD_CO_SIMULATION: vscode.Command = {
     command: 'keith-vscode.add-co-simulation',
-    title: 'Add Co-Simulation'
+    title: 'Add Co-Simulation',
 }
 
 export const SELECT_SIMULATION_CHAIN: vscode.Command = {
     command: 'select-simulation-chain',
-    title: 'Select simulation chain'
+    title: 'Select simulation chain',
 }
 
 export const SELECT_SNAPSHOT_SIMULATION_CHAIN: vscode.Command = {
     command: 'select-snapshot-simulation-chain',
-    title: 'Select snapshot simulation chain'
+    title: 'Select snapshot simulation chain',
 }
 
 export const SET_SIMULATION_SPEED: vscode.Command = {
     command: 'set-simulation-speed',
-    title: 'Set simulation speed'
+    title: 'Set simulation speed',
 }
 
 export const REVEAL_SIMULATION_WIDGET: vscode.Command = {
     command: 'reveal-simulation-widget',
-    title: 'Reveal simulation widget'
+    title: 'Reveal simulation widget',
 }
 
 export const SET_SIMULATION_STEP_DELAY: vscode.Command = {
-    command: "keith-vscode.simulation-step-delay",
-    title: "Set simulation step delay to ..."
+    command: 'keith-vscode.simulation-step-delay',
+    title: 'Set simulation step delay to ...',
 }
 
 export const SET_SIMULATION_TYPE_TO: vscode.Command = {
-    command: "keith-vscode.simulation-type",
-    title: "Set simulation type to ..."
+    command: 'keith-vscode.simulation-type',
+    title: 'Set simulation type to ...',
 }
 
 export const SHOW_INTERNAL_VARIABLES: vscode.Command = {
-    command: "keith-vscode.show-internal-variables",
-    title: "Set display internal variables to ..."
+    command: 'keith-vscode.show-internal-variables',
+    title: 'Set display internal variables to ...',
 }

--- a/keith-vscode/src/simulation/helper.ts
+++ b/keith-vscode/src/simulation/helper.ts
@@ -16,52 +16,49 @@
  * @param ms wait time in ms
  */
 export function delay(ms: number): Promise<unknown> {
-    return new Promise( resolve => setTimeout(resolve, ms) );
+    // eslint-disable-next-line no-promise-executor-return
+    return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 export function strMapToObj(strMap: Map<string, any>): any {
-    const obj = Object.create(null);
+    const obj = Object.create(null)
     strMap.forEach((v, k) => {
         obj[k] = v
-    });
-    return obj;
+    })
+    return obj
 }
 
 export function strMapToJson(strMap: Map<string, any>): string {
-    return JSON.stringify(strMapToObj(strMap));
+    return JSON.stringify(strMapToObj(strMap))
 }
 
 export function isInternal(data: SimulationData): boolean {
-    return data.categories.includes("guard") || data.categories.includes("sccharts-generated") || data.categories.includes("term") || data.categories.includes("ticktime")
+    return (
+        data.categories.includes('guard') ||
+        data.categories.includes('sccharts-generated') ||
+        data.categories.includes('term') ||
+        data.categories.includes('ticktime')
+    )
 }
 
 export function reverse(array: any[]): any[] {
-    return array.map((item, idx) => {
-        item // use item
-        return array[array.length - 1 - idx]
-    })
+    return array.map((item, idx) => array[array.length - 1 - idx])
 }
 
 export function getNonce(): string {
-	let text = '';
-	const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-	for (let i = 0; i < 32; i++) {
-		text += possible.charAt(Math.floor(Math.random() * possible.length));
-	}
-	return text;
+    let text = ''
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length))
+    }
+    return text
 }
 
 /**
  * Internal data structure to save all data required to display a simulation in the siulation view.
  */
- export class SimulationData {
-    constructor(
-        public data: any[],
-        public input: boolean,
-        public output: boolean,
-        public categories: string[]
-    ) {
-    }
+export class SimulationData {
+    constructor(public data: any[], public input: boolean, public output: boolean, public categories: string[]) {}
 }
 
 /**
@@ -77,33 +74,24 @@ export class SimulationStartedMessage {
 }
 
 export class Category {
-    constructor(
-        public name: string,
-        public symbols: string[]
-    ) {
-    }
+    constructor(public name: string, public symbols: string[]) {}
 }
 
 /**
  * Message is used as a request and response parameter for a simulation step.
  */
 export class SimulationStepMessage {
-    constructor(
-        public values: Record<string, unknown>
-    ) {}
+    constructor(public values: Record<string, unknown>) {}
 }
 
 /**
  * Message send by the LS whenever a simulation is stopped.
  */
 export class SimulationStoppedMessage {
-    constructor(
-        public successful: boolean,
-        public message: string
-    ) {}
+    constructor(public successful: boolean, public message: string) {}
 }
 
-export const SimulationDataBlackList: string[]  = ["#interface"]
+export const SimulationDataBlackList: string[] = ['#interface']
 
 /**
  * Message sent by the LS as a response to a load trace message, containing the structure of the loaded trace.
@@ -115,19 +103,19 @@ export class LoadedTraceMessage {
         /* If loading the trace was successful. */
         public successful: boolean,
         /* Human-readable reason why loading failed (if it failed). */
-        public reason: string,
+        public reason: string
     ) {}
 }
 
 /**
  * Message sent by the LS as a response to save the current trace to a file.
  */
- export class SavedTraceMessage {
+export class SavedTraceMessage {
     constructor(
         /* If saving the trace was successful. */
         public successful: boolean,
         /* Human-readable reason why saving failed (if it failed). */
-        public reason: string,
+        public reason: string
     ) {}
 }
 
@@ -143,8 +131,11 @@ export class Trace {
  */
 export class Tick {
     name: string
+
     inputs: Assignment[]
+
     outputs: Assignment[]
+
     goto: Tick // TODO: this probably needs to be converted to some ID instead (the name for example if that is unique or the index in its trace)
 }
 

--- a/keith-vscode/src/simulation/message.ts
+++ b/keith-vscode/src/simulation/message.ts
@@ -11,7 +11,7 @@
  * This code is provided under the terms of the Eclipse Public License (EPL).
  */
 
-import { SimulationData } from "./helper";
+import { SimulationData } from './helper'
 
 // Holds all messages between the simulation view and the simulation provider
 
@@ -20,8 +20,8 @@ export interface WebviewReadyMessage {
 }
 
 export function isWebviewReadyMessage(object: any): object is WebviewReadyMessage {
-    /*eslint no-prototype-builtins: "off"*/
-    return object !== undefined && object.hasOwnProperty('readyMessage');
+    /* eslint no-prototype-builtins: "off" */
+    return object !== undefined && object.hasOwnProperty('readyMessage')
 }
 
 export interface SimulationTableData {
@@ -32,9 +32,11 @@ export interface SimulationTableData {
 }
 
 export function isSimulationData(object: any): object is SimulationTableData {
-    return object !== undefined
-        && object.hasOwnProperty('key')
-        && object.hasOwnProperty('data')
-        && object.hasOwnProperty('inputOutputColumnEnabled')
-        && object.hasOwnProperty('valuesForNextStep'); // TODO really check the type if needed
+    return (
+        object !== undefined &&
+        object.hasOwnProperty('key') &&
+        object.hasOwnProperty('data') &&
+        object.hasOwnProperty('inputOutputColumnEnabled') &&
+        object.hasOwnProperty('valuesForNextStep')
+    ) // TODO really check the type if needed
 }

--- a/keith-vscode/src/simulation/simulation-tree-data-provider.ts
+++ b/keith-vscode/src/simulation/simulation-tree-data-provider.ts
@@ -11,25 +11,51 @@
  * This code is provided under the terms of the Eclipse Public License (EPL).
  */
 
-import * as vscode from 'vscode';
-import * as path from 'path';
-import { LanguageClient } from 'vscode-languageclient';
-import { CompilationDataProvider, CompilationSystem } from '../kico/compilation-data-provider';
-import { ADD_CO_SIMULATION, COMPILE_AND_SIMULATE, COMPILE_AND_SIMULATE_SNAPSHOT, LOAD_TRACE, NEW_VALUE_SIMULATION, OPEN_EXTERNAL_KVIZ_VIEW, PAUSE_SIMULATION, RUN_SIMULATION, SAVE_TRACE, SET_SIMULATION_STEP_DELAY, SET_SIMULATION_TYPE_TO, SHOW_INTERNAL_VARIABLES, SIMULATE, STEP_SIMULATION, STOP_SIMULATION } from './commands';
-import { delay, reverse, SimulationDataBlackList, LoadedTraceMessage, SavedTraceMessage, SimulationStartedMessage, SimulationStepMessage, SimulationStoppedMessage, strMapToObj, Trace } from './helper';
+import * as vscode from 'vscode'
+import * as path from 'path'
+import { LanguageClient } from 'vscode-languageclient'
+import { CompilationDataProvider, CompilationSystem } from '../kico/compilation-data-provider'
+import {
+    ADD_CO_SIMULATION,
+    COMPILE_AND_SIMULATE,
+    COMPILE_AND_SIMULATE_SNAPSHOT,
+    LOAD_TRACE,
+    NEW_VALUE_SIMULATION,
+    OPEN_EXTERNAL_KVIZ_VIEW,
+    PAUSE_SIMULATION,
+    RUN_SIMULATION,
+    SAVE_TRACE,
+    SET_SIMULATION_STEP_DELAY,
+    SET_SIMULATION_TYPE_TO,
+    SHOW_INTERNAL_VARIABLES,
+    SIMULATE,
+    STEP_SIMULATION,
+    STOP_SIMULATION,
+} from './commands'
+import {
+    delay,
+    reverse,
+    SimulationDataBlackList,
+    LoadedTraceMessage,
+    SavedTraceMessage,
+    SimulationStartedMessage,
+    SimulationStepMessage,
+    SimulationStoppedMessage,
+    strMapToObj,
+    Trace,
+} from './helper'
 import { PerformActionAction } from '../perform-action-handler'
-import { SettingsService } from '../settings';
-import { Settings, SimulationType } from '../constants';
-import { Tuple } from '../util';
+import { SettingsService } from '../settings'
+import { Settings, SimulationType } from '../constants'
+import { Tuple } from '../util'
 
-export const externalStepMessageType = 'keith/simulation/didStep';
-export const valuesForNextStepMessageType = 'keith/simulation/valuesForNextStep';
-export const externalStopMessageType = 'keith/simulation/externalStop';
-export const startedSimulationMessageType = 'keith/simulation/started';
+export const externalStepMessageType = 'keith/simulation/didStep'
+export const valuesForNextStepMessageType = 'keith/simulation/valuesForNextStep'
+export const externalStopMessageType = 'keith/simulation/externalStop'
+export const startedSimulationMessageType = 'keith/simulation/started'
 
 // TODO lme: Maybe match naming with CompilationDataProvider
 export class SimulationTreeDataProvider implements vscode.TreeDataProvider<SimulationTreeData> {
-
     public readonly newSimulationDataEmitter = new vscode.EventEmitter<this>()
 
     public readonly newSimulationData: vscode.Event<this> = this.newSimulationDataEmitter.event
@@ -37,13 +63,13 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
     protected readonly onRequestSimulationSystemsEmitter = new vscode.EventEmitter<this | undefined>()
 
     readonly onDidChangeOpenStateEmitter = new vscode.EventEmitter<boolean>()
-    
+
     output: vscode.OutputChannel
 
     /**
      * Trace for each symbol.
      */
-    public simulationData: Map<string, SimulationTreeData> = new Map
+    public simulationData: Map<string, SimulationTreeData> = new Map()
     /**
      * Trace for each symbol.
      */
@@ -52,17 +78,17 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
     /**
      * Holds the value that is set in the next tick. Holds only the inputs of the simulation
      */
-    public valuesForNextStep: Map<string, any> = new Map
+    public valuesForNextStep: Map<string, any> = new Map()
 
     /**
      * Indicates whether an input value should be sent to the server.
      */
-    public changedValuesForNextStep: Map<string, any> = new Map
+    public changedValuesForNextStep: Map<string, any> = new Map()
 
     /**
      * Map which holds wether a event listener is registered for a symbol
      */
-    public eventListenerRegistered: Map<string, boolean> = new Map
+    public eventListenerRegistered: Map<string, boolean> = new Map()
 
     /**
      * Wether next simulation step should be requested after a time specified by simulation delay
@@ -98,9 +124,10 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
     simulationCommands: vscode.Command[] = []
 
     startTime = 0
+
     endTime = 0
 
-	public static readonly viewType = 'kieler-simulation-tree';
+    public static readonly viewType = 'kieler-simulation-tree'
 
     public kico: CompilationDataProvider
 
@@ -112,11 +139,18 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
 
     private simulationStatus: vscode.StatusBarItem
 
-    private _onDidChangeTreeData: vscode.EventEmitter<SimulationTreeData | undefined | null | void> = new vscode.EventEmitter<SimulationTreeData | undefined | null | void>();
-    readonly onDidChangeTreeData: vscode.Event<SimulationTreeData | undefined | null | void> = this._onDidChangeTreeData.event;
+    private _onDidChangeTreeData: vscode.EventEmitter<SimulationTreeData | undefined | null | void> =
+        new vscode.EventEmitter<SimulationTreeData | undefined | null | void>()
 
+    readonly onDidChangeTreeData: vscode.Event<SimulationTreeData | undefined | null | void> =
+        this._onDidChangeTreeData.event
 
-	constructor(lsClient: LanguageClient, kico: CompilationDataProvider, readonly context: vscode.ExtensionContext, private readonly settings: SettingsService<Settings>) {
+    constructor(
+        lsClient: LanguageClient,
+        kico: CompilationDataProvider,
+        readonly context: vscode.ExtensionContext,
+        private readonly settings: SettingsService<Settings>
+    ) {
         console.log('Simulation view tree is created')
         // TODO
         this.lsClient = lsClient
@@ -126,14 +160,14 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
         this.context.subscriptions.push(this.simulationStatus)
 
         // Output channel
-		this.output = vscode.window.createOutputChannel('KIELER Simulation');
+        this.output = vscode.window.createOutputChannel('KIELER Simulation')
 
         // Push context variables for conditional menu items
         vscode.commands.executeCommand('setContext', 'keith.vscode:simulationRunning', this.simulationRunning)
         vscode.commands.executeCommand('setContext', 'keith.vscode:play', this.play)
 
         // Bind to events
-        kico.newSimulationCommands(systems => {
+        kico.newSimulationCommands((systems) => {
             if (typeof systems !== 'undefined') {
                 this.registerSimulationCommands(systems)
             }
@@ -142,7 +176,7 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
         kico.compilationStarted(() => {
             this.compilationStarted()
         })
-        kico.compilationFinished(success => {
+        kico.compilationFinished((success) => {
             if (typeof success !== 'undefined') {
                 this.compilationFinished(success)
             }
@@ -156,65 +190,71 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
         lsClient.onReady().then(() => {
             lsClient.onNotification(externalStepMessageType, (message: SimulationStepMessage) => {
                 this.handleStepMessage(message)
-            });
+            })
             lsClient.onNotification(valuesForNextStepMessageType, (message: SimulationStepMessage) => {
                 this.handleExternalNewUserValue(message)
-            });
+            })
             lsClient.onNotification(externalStopMessageType, (message: string) => {
                 this.handleExternalStop(message)
-            });
+            })
             lsClient.onNotification(startedSimulationMessageType, (message: SimulationStartedMessage) => {
                 this.handleSimulationStarted(message)
-            });
+            })
         })
 
         // TODO Create commands
         this.context.subscriptions.push(
             vscode.commands.registerCommand(SIMULATE.command, async () => {
                 this.simulate()
-            }));
-        
+            })
+        )
+
         this.context.subscriptions.push(
             vscode.commands.registerCommand(STOP_SIMULATION.command, async () => {
                 this.stopSimulation()
-            }));
-        
+            })
+        )
+
         this.context.subscriptions.push(
             vscode.commands.registerCommand(STEP_SIMULATION.command, async () => {
                 this.executeSimulationStep()
-            }));
-        
+            })
+        )
+
         this.context.subscriptions.push(
             vscode.commands.registerCommand(PAUSE_SIMULATION.command, async () => {
                 this.startOrPauseSimulation()
-            }));
-        
+            })
+        )
+
         this.context.subscriptions.push(
             vscode.commands.registerCommand(RUN_SIMULATION.command, async () => {
                 this.startOrPauseSimulation()
-            }));
-        
+            })
+        )
+
         this.context.subscriptions.push(
             vscode.commands.registerCommand(SAVE_TRACE.command, async () => {
                 this.saveTrace()
-            }));
-    
+            })
+        )
+
         this.context.subscriptions.push(
             vscode.commands.registerCommand(LOAD_TRACE.command, async () => {
                 this.loadTrace()
-            }));
-
+            })
+        )
 
         // Simulation quickpick commands
 
         this.context.subscriptions.push(
             vscode.commands.registerCommand(COMPILE_AND_SIMULATE.command, async () => {
                 const options = this.createQuickPick(this.systems)
-                const quickPick = vscode.window.createQuickPick();
-                quickPick.items = options;
-                quickPick.onDidChangeSelection(selection => {
+                const quickPick = vscode.window.createQuickPick()
+                quickPick.items = options
+                quickPick.onDidChangeSelection((selection) => {
                     if (selection[0]) {
-                        this.systems.forEach(system => {
+                        this.systems.forEach((system) => {
                             if (system.label === selection[0].label) {
                                 kico.compile(system.id, true, false, system.snapshotSystem)
                                 this.compilingSimulation = true
@@ -222,93 +262,102 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
                         })
                     }
                     quickPick.hide()
-                });
-                quickPick.onDidHide(() => quickPick.dispose());
-                quickPick.show();
-                
-            }));
-    
+                })
+                quickPick.onDidHide(() => quickPick.dispose())
+                quickPick.show()
+            })
+        )
+
         this.context.subscriptions.push(
             vscode.commands.registerCommand(COMPILE_AND_SIMULATE_SNAPSHOT.command, async () => {
                 const options = this.createQuickPick(this.snapshotSystems)
-                const quickPick = vscode.window.createQuickPick();
-                quickPick.items = options;
-                quickPick.onDidChangeSelection(selection => {
+                const quickPick = vscode.window.createQuickPick()
+                quickPick.items = options
+                quickPick.onDidChangeSelection((selection) => {
                     if (selection[0]) {
-                        this.snapshotSystems.forEach(system => {
+                        this.snapshotSystems.forEach((system) => {
                             if (system.label === selection[0].label) {
                                 kico.compile(system.id, true, false, system.snapshotSystem)
                             }
                         })
                     }
                     quickPick.hide()
-                });
-                quickPick.onDidHide(() => quickPick.dispose());
-                quickPick.show();
-                
-            }));
-        
+                })
+                quickPick.onDidHide(() => quickPick.dispose())
+                quickPick.show()
+            })
+        )
+
         // Kviz commands
 
         this.context.subscriptions.push(
-            vscode.commands.registerCommand(OPEN_EXTERNAL_KVIZ_VIEW.command, this.openExternalKVizView, this));
-        
+            vscode.commands.registerCommand(OPEN_EXTERNAL_KVIZ_VIEW.command, this.openExternalKVizView, this)
+        )
+
         this.context.subscriptions.push(
-            vscode.commands.registerCommand(ADD_CO_SIMULATION.command, this.handleAddCoSimulation, this));
-        
+            vscode.commands.registerCommand(ADD_CO_SIMULATION.command, this.handleAddCoSimulation, this)
+        )
+
         this.context.subscriptions.push(
-            vscode.commands.registerCommand(NEW_VALUE_SIMULATION.command, this.newInputValue, this));
+            vscode.commands.registerCommand(NEW_VALUE_SIMULATION.command, this.newInputValue, this)
+        )
 
         // settings commands
         this.context.subscriptions.push(
             vscode.commands.registerCommand(SET_SIMULATION_STEP_DELAY.command, async () => {
-                const input = await vscode.window.showInputBox({validateInput: (val) => isNaN(parseInt(val, 10)) ? "Given input is not a valid number!" : null})
-                if (input != undefined) {
-                    const simulationSetDelay = parseInt(input, 10);
-                    this.settings.set("simulationStepDelay", simulationSetDelay);
+                const input = await vscode.window.showInputBox({
+                    // eslint-disable-next-line no-restricted-globals
+                    validateInput: (val) => (isNaN(parseInt(val, 10)) ? 'Given input is not a valid number!' : null),
+                })
+                if (input !== undefined) {
+                    const simulationSetDelay = parseInt(input, 10)
+                    this.settings.set('simulationStepDelay', simulationSetDelay)
                 }
             })
-        );
+        )
 
         this.context.subscriptions.push(
             vscode.commands.registerCommand(SET_SIMULATION_TYPE_TO.command, () => {
                 const simulationTypes: Tuple<SimulationType> = ['Manual', 'Periodic', 'Dynamic']
-                const options: vscode.QuickPickItem[] = simulationTypes.map(type => ({
+                const options: vscode.QuickPickItem[] = simulationTypes.map((type) => ({
                     label: type,
-                    picked: this.settings.get("simulationType") === type
+                    picked: this.settings.get('simulationType') === type,
                 }))
-                const quickPick = vscode.window.createQuickPick();
-                quickPick.items = options;
-                quickPick.onDidChangeSelection(selection => {
+                const quickPick = vscode.window.createQuickPick()
+                quickPick.items = options
+                quickPick.onDidChangeSelection((selection) => {
                     if (selection[0]) {
-                        this.settings.set("simulationType", selection[0].label as SimulationType)
+                        this.settings.set('simulationType', selection[0].label as SimulationType)
                     }
-                    quickPick.hide();
+                    quickPick.hide()
                 })
-                quickPick.onDidHide(quickPick.dispose);
-                quickPick.show();
+                quickPick.onDidHide(quickPick.dispose)
+                quickPick.show()
             })
         )
 
         this.context.subscriptions.push(
             vscode.commands.registerCommand(SHOW_INTERNAL_VARIABLES.command, () => {
-                const options: vscode.QuickPickItem[] = [{
-                    label: 'true',
-                    picked: this.settings.get("showInternalVariables.enabled")
-                }, {
-                    label: 'false',
-                    picked: !this.settings.get("showInternalVariables.enabled")
-                }];
-                const quickPick = vscode.window.createQuickPick();
-                quickPick.items = options;
-                quickPick.onDidChangeSelection(selection => {
+                const options: vscode.QuickPickItem[] = [
+                    {
+                        label: 'true',
+                        picked: this.settings.get('showInternalVariables.enabled'),
+                    },
+                    {
+                        label: 'false',
+                        picked: !this.settings.get('showInternalVariables.enabled'),
+                    },
+                ]
+                const quickPick = vscode.window.createQuickPick()
+                quickPick.items = options
+                quickPick.onDidChangeSelection((selection) => {
                     if (selection[0]) {
-                        this.settings.set("showInternalVariables.enabled", selection[0]?.label === 'true')
+                        this.settings.set('showInternalVariables.enabled', selection[0]?.label === 'true')
                     }
-                    quickPick.hide();
+                    quickPick.hide()
                 })
-                quickPick.onDidHide(quickPick.dispose);
-                quickPick.show();
+                quickPick.onDidHide(quickPick.dispose)
+                quickPick.show()
             })
         )
     }
@@ -324,49 +373,58 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
             } else {
                 element.description = JSON.stringify(element.data[element.data.length - 1])
             }
-            element.contextValue
-            return element
-        } else if (element.contextValue?.startsWith('simulation:history')) {
+            // FIXME can this be removed? element.contextValue
             return element
         }
-        throw new Error('Tree item is not defined.');
+        if (element.contextValue?.startsWith('simulation:history')) {
+            return element
+        }
+        throw new Error('Tree item is not defined.')
     }
 
     getChildren(element?: SimulationTreeData): vscode.ProviderResult<SimulationTreeData[]> {
         if (this.simulationData) {
             if (element === undefined) {
                 const result: SimulationTreeData[] = []
-                this.simulationData.forEach((element: SimulationTreeData) => {
-
-                    if (!(SimulationDataBlackList.includes(element.id) || element.id.includes('_tickCounter') || element.id.startsWith('_') || element.id.startsWith('#'))) {
-                        element.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed
-                        element.contextValue = 'simulation:data' + (element.input? ':input' : '')
-                        result.push(element)
+                this.simulationData.forEach((treeData: SimulationTreeData) => {
+                    if (
+                        !(
+                            SimulationDataBlackList.includes(treeData.id) ||
+                            treeData.id.includes('_tickCounter') ||
+                            treeData.id.startsWith('_') ||
+                            treeData.id.startsWith('#')
+                        )
+                    ) {
+                        treeData.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed
+                        treeData.contextValue = `simulation:data${treeData.input ? ':input' : ''}`
+                        result.push(treeData)
                     }
                 })
                 return result
-            } else if (element.contextValue?.startsWith('simulation:data')) {
+            }
+            if (element.contextValue?.startsWith('simulation:data')) {
                 const history = new SimulationTreeData(
                     JSON.stringify(reverse(element.data)),
-                    element.id + 'history',
+                    `${element.id}history`,
                     vscode.TreeItemCollapsibleState.None,
                     element.data,
                     element.input,
                     element.output,
                     element.categories
                 )
-                history.contextValue = 'simulation:history' + (element.input? ':input' : '')
+                history.contextValue = `simulation:history${element.input ? ':input' : ''}`
                 if (history.input) {
                     history.command = {
                         title: NEW_VALUE_SIMULATION.title,
                         command: NEW_VALUE_SIMULATION.command,
-                        arguments: [element]
+                        arguments: [element],
                     }
                 }
                 return [history]
             }
             // No element other than the root element with its children is shown
         }
+        return null // FIXME Is null really something we want to return here?
     }
 
     public update(): void {
@@ -376,12 +434,12 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
 
     createQuickPick(systems: CompilationSystem[]): vscode.QuickPickItem[] {
         const quickPicks: vscode.QuickPickItem[] = []
-        systems.forEach(system => {
+        systems.forEach((system) => {
             quickPicks.push({
-                label: system.label
+                label: system.label,
             })
-        });
-        return quickPicks;
+        })
+        return quickPicks
     }
 
     // SIMULATION
@@ -393,13 +451,13 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
     registerSimulationCommands(systems: CompilationSystem[]): void {
         this.systems = []
         this.snapshotSystems = []
-        systems.forEach(system => {
+        systems.forEach((system) => {
             if (system.snapshotSystem) {
                 this.snapshotSystems.push(system)
             } else {
                 this.systems.push(system)
             }
-        });
+        })
         this.simulationStatus.hide()
     }
 
@@ -427,39 +485,41 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
     }
 
     async handleAddCoSimulation(action: PerformActionAction): Promise<void> {
-        action
         // TODO Uri of simulation file
         const executableUri = await vscode.window.showOpenDialog({
             title: 'Select CoSimulation executable',
             canSelectFolders: false,
             canSelectFiles: true,
-            canSelectMany: false
-
-        });
+            canSelectMany: false,
+        })
         if (executableUri) {
             const lClient = await this.lsClient
-            lClient.sendNotification('keith/simulation/addCoSimulation', ['keith-diagram_sprotty',
-                 executableUri[0].path.toString()])
+            lClient.sendNotification('keith/simulation/addCoSimulation', [
+                'keith-diagram_sprotty',
+                executableUri[0].path.toString(),
+            ])
         }
     }
 
-    async newInputValue(simulationData: SimulationTreeData) : Promise<void> {
+    async newInputValue(simulationData: SimulationTreeData): Promise<void> {
         const result = await vscode.window.showInputBox({
             value: JSON.stringify(simulationData.data[simulationData.data.length - 1]),
-            placeHolder: 'Input value for ' + simulationData.id,
-            title: 'New value for ' + simulationData.id,
-            validateInput: (text => {
+            placeHolder: `Input value for ${simulationData.id}`,
+            title: `New value for ${simulationData.id}`,
+            validateInput: (text) => {
                 let valid = false
                 if (!text) {
                     return ''
                 }
                 try {
-                    valid = (simulationData.data.length == 0) || typeof JSON.parse(text) === typeof simulationData.data[simulationData.data.length - 1]
+                    valid =
+                        simulationData.data.length === 0 ||
+                        typeof JSON.parse(text) === typeof simulationData.data[simulationData.data.length - 1]
                 } catch (e) {
                     // We do not care but we also do not set valid
                 }
-                return valid ? '' : 'Input is not type of ' + typeof simulationData.data[simulationData.data.length - 1]
-            })
+                return valid ? '' : `Input is not type of ${typeof simulationData.data[simulationData.data.length - 1]}`
+            },
         })
         if (result) {
             this.valuesForNextStep.set(simulationData.id, JSON.parse(result))
@@ -478,15 +538,16 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
             // The uri of the current editor is needed to identify the already compiled snapshot that is used to start the simulation.
             const uri = this.kico.lastCompiledUri
             this.lsClient.onReady().then(() => {
-                this.lsClient.sendNotification('keith/simulation/start', [uri, this.settings.get("simulationType")])
+                this.lsClient.sendNotification('keith/simulation/start', [uri, this.settings.get('simulationType')])
             })
-            this.simulationStatus.text = '$(spinner) Starting simulation...',
-            this.simulationStatus.tooltip ='Starting simulation...'
+            this.simulationStatus.text = '$(spinner) Starting simulation...'
+            this.simulationStatus.tooltip = 'Starting simulation...'
             this.simulationStatus.show()
-            
         } else {
-            this.simulationStatus.text = `$(times) ${this.kico.editor ? 'Simulation already running' : 'No editor defined'}`,
-            this.simulationStatus.tooltip ='Did not simulate.'
+            this.simulationStatus.text = `$(times) ${
+                this.kico.editor ? 'Simulation already running' : 'No editor defined'
+            }`
+            this.simulationStatus.tooltip = 'Did not simulate.'
             this.simulationStatus.show()
         }
     }
@@ -498,20 +559,21 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
         this.endTime = Date.now()
         if (!startMessage.successful) {
             this.startTime = Date.now()
-            this.simulationStatus.text = `$(cross) (${(this.endTime - this.startTime).toPrecision(3)}ms) Simulation could not be started`,
-            this.simulationStatus.tooltip ='Did not simulate.'
+            this.simulationStatus.text = `$(cross) (${(this.endTime - this.startTime).toPrecision(
+                3
+            )}ms) Simulation could not be started`
+            this.simulationStatus.tooltip = 'Did not simulate.'
             this.simulationStatus.show()
             // TODO this.messageService.error(startMessage.error) TODO
             return
-        } else {
-            this.simulationStatus.text = `$(check) (${(this.endTime - this.startTime).toPrecision(3)}ms) Simulating...`,
-            this.simulationStatus.tooltip =''
-            this.simulationStatus.show()
         }
+        this.simulationStatus.text = `$(check) (${(this.endTime - this.startTime).toPrecision(3)}ms) Simulating...`
+        this.simulationStatus.tooltip = ''
+        this.simulationStatus.show()
 
         // Get the start configuration for the simulation
-        const pool: Map<string, any> = new Map(Object.entries(startMessage.dataPool));
-        const propertySet: Map<string, any> = new Map(Object.entries(startMessage.propertySet));
+        const pool: Map<string, any> = new Map(Object.entries(startMessage.dataPool))
+        const propertySet: Map<string, any> = new Map(Object.entries(startMessage.propertySet))
         // Inputs and outputs are handled separately
         let inputs: string[] = propertySet.get('input')
         inputs = inputs === undefined ? [] : inputs
@@ -536,7 +598,8 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
                 data: [],
                 input: inputs.includes(key),
                 output: outputs.includes(key),
-                categories: categoriesList}
+                categories: categoriesList,
+            }
             this.simulationData.set(key, newData)
             // this.simulationTreeData.push(newData)
             // Set the value for which will be set for the next step for inputs
@@ -570,16 +633,18 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
      */
     public async stopSimulation(): Promise<void> {
         this.setValuesToStopSimulation()
-        this.simulationStatus.text = '$(spinner) Stopping simulation...',
+        this.simulationStatus.text = '$(spinner) Stopping simulation...'
         this.simulationStatus.tooltip = 'Request to stop the simulation is about to be send'
         this.simulationStatus.show()
         const lClient = await this.lsClient
-        const message: SimulationStoppedMessage = await lClient.sendRequest('keith/simulation/stop') as SimulationStoppedMessage
+        const message: SimulationStoppedMessage = (await lClient.sendRequest(
+            'keith/simulation/stop'
+        )) as SimulationStoppedMessage
         if (!message.successful) {
             // TODO this.messageService.error(message.message) TODO
         }
         this.update()
-        this.simulationStatus.text = 'Stopped simulation',
+        this.simulationStatus.text = 'Stopped simulation'
         this.simulationStatus.tooltip = ''
         this.simulationStatus.show()
     }
@@ -614,11 +679,13 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
      */
     async saveTrace(): Promise<void> {
         // Ask the user where to save this trace
-        const currentFolder = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : undefined
+        const currentFolder = vscode.workspace.workspaceFolders
+            ? vscode.workspace.workspaceFolders[0].uri.fsPath
+            : undefined
         const uri = await vscode.window.showSaveDialog({
-            filters: {'KTrace': ['ktrace']},
+            filters: { KTrace: ['ktrace'] },
             title: 'Save current KTrace to...',
-            defaultUri: currentFolder ? vscode.Uri.file(currentFolder + '/trace.ktrace') : undefined,
+            defaultUri: currentFolder ? vscode.Uri.file(`${currentFolder}/trace.ktrace`) : undefined,
         })
         if (uri === undefined) {
             // The user did not pick any file to save to.
@@ -627,12 +694,11 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
 
         // Request the LS to save the current trace into the file picked by the user.
         const lsClient = await this.lsClient
-        const message = await lsClient.sendRequest('keith/simulation/saveTrace', uri.path) as SavedTraceMessage
+        const message = (await lsClient.sendRequest('keith/simulation/saveTrace', uri.path)) as SavedTraceMessage
         if (!message.successful) {
-            const errorMessage = 'could not save trace: ' + message.reason
-            this.output.appendLine('[ERROR]\t' + errorMessage)
+            const errorMessage = `could not save trace: ${message.reason}`
+            this.output.appendLine(`[ERROR]\t${errorMessage}`)
             vscode.window.showErrorMessage(errorMessage)
-            return
         }
     }
 
@@ -642,8 +708,8 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
     async loadTrace(): Promise<void> {
         // Loading the trace file.
         const uris = await vscode.window.showOpenDialog({
-            canSelectMany: false, 
-            filters: {'KTrace': ['ktrace']},
+            canSelectMany: false,
+            filters: { KTrace: ['ktrace'] },
         })
         if (uris === undefined) {
             // The user did not pick any file to load.
@@ -652,11 +718,11 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
 
         // Send the trace file uri to the server to convert it into a Trace model and to load it.
         const lClient = await this.lsClient
-        const message = await lClient.sendRequest('keith/simulation/loadTrace', uris[0].path) as LoadedTraceMessage
+        const message = (await lClient.sendRequest('keith/simulation/loadTrace', uris[0].path)) as LoadedTraceMessage
 
         if (!message.successful) {
-            const errorMessage = 'could not load trace: ' + message.reason
-            this.output.appendLine('[ERROR]\t' + errorMessage)
+            const errorMessage = `could not load trace: ${message.reason}`
+            this.output.appendLine(`[ERROR]\t${errorMessage}`)
             vscode.window.showErrorMessage(errorMessage)
             return
         }
@@ -670,7 +736,8 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
     async waitForNextStep(): Promise<void> {
         while (this.play) {
             this.executeSimulationStep()
-            await delay(this.settings.get("simulationStepDelay"))
+            // eslint-disable-next-line no-await-in-loop
+            await delay(this.settings.get('simulationStepDelay'))
         }
     }
 
@@ -679,7 +746,7 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
      * @param message data of step, includes new values.
      */
     handleStepMessage(message: SimulationStepMessage): boolean {
-        const pool: Map<string, any> = new Map(Object.entries(message.values));
+        const pool: Map<string, any> = new Map(Object.entries(message.values))
         if (pool) {
             pool.forEach((value, key) => {
                 // push value in history and set new input value
@@ -697,7 +764,7 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
                     this.stopSimulation()
                     // TODO this.messageService.error("Unexpected value for " + key + "in simulation data, stopping simulation")
                 }
-            });
+            })
         } else {
             // TODO this.messageService.error('Simulation data values are undefined') TODO
         }
@@ -710,14 +777,13 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
         return true
     }
 
-    handleExternalNewUserValue(values: unknown):void {
+    handleExternalNewUserValue(values: unknown): void {
         console.log('external value', values)
         // this.messageService.warn('External new user values are not implemented')
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     handleExternalStop(message: string): void {
-        message
         // TODO this.messageService.error('Stopped simulation because of exception on LS. You might want to reload the window.') TODO
         // this.messageService.error(message)
         this.setValuesToStopSimulation()
@@ -734,10 +800,8 @@ export class SimulationTreeDataProvider implements vscode.TreeDataProvider<Simul
     }
 
     getExtensionFileUri(...segments: string[]): vscode.Uri {
-        return vscode.Uri
-            .file(path.join(this.context.extensionPath, ...segments));
+        return vscode.Uri.file(path.join(this.context.extensionPath, ...segments))
     }
-
 }
 
 export class SimulationTreeData extends vscode.TreeItem {
@@ -748,9 +812,9 @@ export class SimulationTreeData extends vscode.TreeItem {
         public data: any[],
         public input: boolean,
         public output: boolean,
-        public categories: string[],
+        public categories: string[]
     ) {
-        super(label, collapsibleState);
-        this.tooltip = `Set ${this.label} to...`;
+        super(label, collapsibleState)
+        this.tooltip = `Set ${this.label} to...`
     }
 }

--- a/keith-vscode/src/simulation/style/index.css
+++ b/keith-vscode/src/simulation/style/index.css
@@ -52,8 +52,10 @@
     outline: none;
     cursor: pointer;
     border-radius: 1px;
-    box-shadow: 0px 1px 5px 0px var(--vscode-checkbox-border), 0px 1px 2px 0px var(--vscode-checkbox-border), 0px 1px 1px -2px var(--vscode-checkbox-border);
-    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    box-shadow: 0px 1px 5px 0px var(--vscode-checkbox-border), 0px 1px 2px 0px var(--vscode-checkbox-border),
+        0px 1px 1px -2px var(--vscode-checkbox-border);
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
+        box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     width: 100%;
 }
 
@@ -68,8 +70,10 @@
     border-radius: 0;
     outline: none;
     cursor: pointer;
-    box-shadow: 0px 1px 5px 0px var(--vscode-checkbox-border), 0px 1px 2px 0px var(--vscode-checkbox-border), 0px 1px 1px -2px var(--vscode-checkbox-border);
-    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    box-shadow: 0px 1px 5px 0px var(--vscode-checkbox-border), 0px 1px 2px 0px var(--vscode-checkbox-border),
+        0px 1px 1px -2px var(--vscode-checkbox-border);
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
+        box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     display: inline-block;
     text-align: center;
     vertical-align: middle;
@@ -86,7 +90,7 @@
 .simulation-panel {
     margin-top: 12px;
     display: flex;
-    margin-left: calc(var(--vscode-ui-padding)*2);
+    margin-left: calc(var(--vscode-ui-padding) * 2);
 }
 
 .icon {
@@ -114,8 +118,10 @@
     border-radius: 0;
     outline: none;
     cursor: pointer;
-    box-shadow: 0px 1px 5px 0px var(--vscode-checkbox-border), 0px 1px 2px 0px var(--vscode-checkbox-border), 0px 1px 1px -2px var(--vscode-checkbox-border);
-    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+    box-shadow: 0px 1px 5px 0px var(--vscode-checkbox-border), 0px 1px 2px 0px var(--vscode-checkbox-border),
+        0px 1px 1px -2px var(--vscode-checkbox-border);
+    transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
+        box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
     display: inline-block;
     text-align: center;
     vertical-align: middle;
@@ -138,7 +144,7 @@ simulation-td {
 .simulation-div {
     margin: 0px;
     padding: 0px;
-    display:block;
+    display: block;
     resize: horizontal;
 }
 

--- a/keith-vscode/src/storage.ts
+++ b/keith-vscode/src/storage.ts
@@ -1,18 +1,31 @@
-import { Memento } from "vscode";
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ *
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ *
+ * This code is provided under the terms of the Eclipse Public License (EPL).
+ */
+
+import { Memento } from 'vscode'
 
 type STORAGE_ITEMS = {
-    'keith.vscode.compilation.auto': boolean;
-    'keith.vscode.compilation.inplace': boolean;
-    'keith.vscode.compilation.showResultingModel': boolean;
-    'keith.vscode.compilation.showButtons': boolean;
-    'keith.vscode.compilation.showPrivateSystems': boolean;
-    'keith.vscode.simulation.simulationStepDelay': number;
-    'keith.vscode.simulation.simulationType': string;
-    'keith.vscode.simulation.showInternalVariables': boolean;
-};
+    'keith.vscode.compilation.auto': boolean
+    'keith.vscode.compilation.inplace': boolean
+    'keith.vscode.compilation.showResultingModel': boolean
+    'keith.vscode.compilation.showButtons': boolean
+    'keith.vscode.compilation.showPrivateSystems': boolean
+    'keith.vscode.simulation.simulationStepDelay': number
+    'keith.vscode.simulation.simulationType': string
+    'keith.vscode.simulation.showInternalVariables': boolean
+}
 
 /**
- * Wrapper around the Memento API provided by VSCode. 
+ * Wrapper around the Memento API provided by VSCode.
  * @deprecated
  */
 export class StorageService {
@@ -20,13 +33,12 @@ export class StorageService {
 
     /**
      * Store a simple key-value-pair.
-     * 
+     *
      * @param key key of the item to put into storage
      * @param value value to store
      */
     public async put<K extends keyof STORAGE_ITEMS>(key: K, value: STORAGE_ITEMS[K]): Promise<void> {
-        await this.memento.update(key, value);
-        
+        await this.memento.update(key, value)
     }
 
     /**
@@ -34,8 +46,9 @@ export class StorageService {
      * @param key key under which the value is stored
      * @param defaultValue a default value, if there is no value in storage
      */
-    public get<K extends keyof STORAGE_ITEMS>(key: K, defaultValue: STORAGE_ITEMS[K]): STORAGE_ITEMS[K];
+    public get<K extends keyof STORAGE_ITEMS>(key: K, defaultValue: STORAGE_ITEMS[K]): STORAGE_ITEMS[K]
+
     public get<K extends keyof STORAGE_ITEMS>(key: K, defaultValue?: STORAGE_ITEMS[K]): STORAGE_ITEMS[K] | undefined {
-        return this.memento.get<STORAGE_ITEMS[K]>(key) ?? defaultValue;
+        return this.memento.get<STORAGE_ITEMS[K]>(key) ?? defaultValue
     }
 }

--- a/keith-vscode/src/util.ts
+++ b/keith-vscode/src/util.ts
@@ -1,15 +1,22 @@
+/*
+ * KIELER - Kiel Integrated Environment for Layout Eclipse RichClient
+ *
+ * http://rtsys.informatik.uni-kiel.de/kieler
+ *
+ * Copyright 2022 by
+ * + Kiel University
+ *   + Department of Computer Science
+ *     + Real-Time and Embedded Systems Group
+ *
+ * This code is provided under the terms of the Eclipse Public License (EPL).
+ */
+
+type UnionToIntersection<U> = (U extends never ? never : (arg: U) => never) extends (arg: infer I) => void ? I : never
+
 /**
  * Helper type to construct a tuple from a union.
  * @param T enum to transform into an union
  */
-export type Tuple<T> = UnionToIntersection<
-T extends never ? never : (t: T) => T
-> extends (_: never) => infer W
-? [...Tuple<Exclude<T, W>>, W]
-: [];
-
-type UnionToIntersection<U> = (
-    U extends never ? never : (arg: U) => never
-  ) extends (arg: infer I) => void
-    ? I
-    : never;
+export type Tuple<T> = UnionToIntersection<T extends never ? never : (t: T) => T> extends (_: never) => infer W
+    ? [...Tuple<Exclude<T, W>>, W]
+    : []

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "prebuild": "yarn clean",
         "build": "lerna run build",
         "watch": "lerna run watch --parallel",
-        "package": "lerna run build && lerna run package --parallel"
+        "package": "lerna run build && lerna run package --parallel",
+        "prettier": "prettier --write keith-vscode/src/"
     },
     "dependencies": {},
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^4.27.0",
-        "@typescript-eslint/parser": "^4.27.0",
-        "eslint": "^7.28.0",
         "lerna": "^4.0.0",
         "typescript": "^4.3.2"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.12.11":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
-  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
-  dependencies:
-    "@babel/highlight" "^7.10.4"
-
 "@babel/code-frame@^7.0.0":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
@@ -21,7 +14,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
   integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
 
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.14.5":
+"@babel/highlight@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
   integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
@@ -35,20 +28,34 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz#9283c9ce5b289a3c4f61c12757469e59377f81f3"
   integrity sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==
 
-"@eslint/eslintrc@^0.4.2":
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.2.tgz#f63d0ef06f5c0c57d76c4ab5f63d3835c51b0179"
-  integrity sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==
+"@eslint/eslintrc@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"
+  integrity sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==
   dependencies:
     ajv "^6.12.4"
-    debug "^4.1.1"
-    espree "^7.3.0"
+    debug "^4.3.2"
+    espree "^9.2.0"
     globals "^13.9.0"
     ignore "^4.0.6"
     import-fresh "^3.2.1"
-    js-yaml "^3.13.1"
+    js-yaml "^4.1.0"
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
+
+"@humanwhocodes/config-array@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"
+  integrity sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.1"
+    debug "^4.1.1"
+    minimatch "^3.0.4"
+
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@lerna/add@4.0.0":
   version "4.0.0"
@@ -940,15 +947,15 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.8":
+"@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
-"@types/json-schema@^7.0.7":
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
-  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/minimatch@*":
   version "3.0.5"
@@ -1009,75 +1016,75 @@
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.60.0.tgz#9330c317691b4f53441a18b598768faeeb71618a"
   integrity sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==
 
-"@typescript-eslint/eslint-plugin@^4.27.0":
-  version "4.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.27.0.tgz#0b7fc974e8bc9b2b5eb98ed51427b0be529b4ad0"
-  integrity sha512-DsLqxeUfLVNp3AO7PC3JyaddmEHTtI9qTSAs+RB6ja27QvIM0TA8Cizn1qcS6vOu+WDLFJzkwkgweiyFhssDdQ==
+"@typescript-eslint/eslint-plugin@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.5.0.tgz#12d5f47f127af089b985f3a205c0e34a812f8fce"
+  integrity sha512-4bV6fulqbuaO9UMXU0Ia0o6z6if+kmMRW8rMRyfqXj/eGrZZRGedS4n0adeGNnjr8LKAM495hrQ7Tea52UWmQA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.27.0"
-    "@typescript-eslint/scope-manager" "4.27.0"
-    debug "^4.3.1"
+    "@typescript-eslint/experimental-utils" "5.5.0"
+    "@typescript-eslint/scope-manager" "5.5.0"
+    debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
-    lodash "^4.17.21"
-    regexpp "^3.1.0"
+    ignore "^5.1.8"
+    regexpp "^3.2.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.27.0":
-  version "4.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.27.0.tgz#78192a616472d199f084eab8f10f962c0757cd1c"
-  integrity sha512-n5NlbnmzT2MXlyT+Y0Jf0gsmAQzCnQSWXKy4RGSXVStjDvS5we9IWbh7qRVKdGcxT0WYlgcCYUK/HRg7xFhvjQ==
+"@typescript-eslint/experimental-utils@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.5.0.tgz#3fe2514dc2f3cd95562206e4058435ea51df609e"
+  integrity sha512-kjWeeVU+4lQ1SLYErRKV5yDXbWDPkpbzTUUlfAUifPYvpX0qZlrcCZ96/6oWxt3QxtK5WVhXz+KsnwW9cIW+3A==
   dependencies:
-    "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.27.0"
-    "@typescript-eslint/types" "4.27.0"
-    "@typescript-eslint/typescript-estree" "4.27.0"
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.5.0"
+    "@typescript-eslint/types" "5.5.0"
+    "@typescript-eslint/typescript-estree" "5.5.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.27.0":
-  version "4.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.27.0.tgz#85447e573364bce4c46c7f64abaa4985aadf5a94"
-  integrity sha512-XpbxL+M+gClmJcJ5kHnUpBGmlGdgNvy6cehgR6ufyxkEJMGP25tZKCaKyC0W/JVpuhU3VU1RBn7SYUPKSMqQvQ==
+"@typescript-eslint/parser@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.5.0.tgz#a38070e225330b771074daa659118238793f7fcd"
+  integrity sha512-JsXBU+kgQOAgzUn2jPrLA+Rd0Y1dswOlX3hp8MuRO1hQDs6xgHtbCXEiAu7bz5hyVURxbXcA2draasMbNqrhmg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.27.0"
-    "@typescript-eslint/types" "4.27.0"
-    "@typescript-eslint/typescript-estree" "4.27.0"
-    debug "^4.3.1"
+    "@typescript-eslint/scope-manager" "5.5.0"
+    "@typescript-eslint/types" "5.5.0"
+    "@typescript-eslint/typescript-estree" "5.5.0"
+    debug "^4.3.2"
 
-"@typescript-eslint/scope-manager@4.27.0":
-  version "4.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.27.0.tgz#b0b1de2b35aaf7f532e89c8e81d0fa298cae327d"
-  integrity sha512-DY73jK6SEH6UDdzc6maF19AHQJBFVRf6fgAXHPXCGEmpqD4vYgPEzqpFz1lf/daSbOcMpPPj9tyXXDPW2XReAw==
+"@typescript-eslint/scope-manager@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.5.0.tgz#2b9f3672fa6cddcb4160e7e8b49ef1fd00f83c09"
+  integrity sha512-0/r656RmRLo7CbN4Mdd+xZyPJ/fPCKhYdU6mnZx+8msAD8nJSP8EyCFkzbd6vNVZzZvWlMYrSNekqGrCBqFQhg==
   dependencies:
-    "@typescript-eslint/types" "4.27.0"
-    "@typescript-eslint/visitor-keys" "4.27.0"
+    "@typescript-eslint/types" "5.5.0"
+    "@typescript-eslint/visitor-keys" "5.5.0"
 
-"@typescript-eslint/types@4.27.0":
-  version "4.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.27.0.tgz#712b408519ed699baff69086bc59cd2fc13df8d8"
-  integrity sha512-I4ps3SCPFCKclRcvnsVA/7sWzh7naaM/b4pBO2hVxnM3wrU51Lveybdw5WoIktU/V4KfXrTt94V9b065b/0+wA==
+"@typescript-eslint/types@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.5.0.tgz#fee61ae510e84ed950a53937a2b443e078107003"
+  integrity sha512-OaYTqkW3GnuHxqsxxJ6KypIKd5Uw7bFiQJZRyNi1jbMJnK3Hc/DR4KwB6KJj6PBRkJJoaNwzMNv9vtTk87JhOg==
 
-"@typescript-eslint/typescript-estree@4.27.0":
-  version "4.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.27.0.tgz#189a7b9f1d0717d5cccdcc17247692dedf7a09da"
-  integrity sha512-KH03GUsUj41sRLLEy2JHstnezgpS5VNhrJouRdmh6yNdQ+yl8w5LrSwBkExM+jWwCJa7Ct2c8yl8NdtNRyQO6g==
+"@typescript-eslint/typescript-estree@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.5.0.tgz#12f422698c1636bd0206086bbec9844c54625ebc"
+  integrity sha512-pVn8btYUiYrjonhMAO0yG8lm7RApzy2L4RC7Td/mC/qFkyf6vRbGyZozoA94+w6D2Y2GRqpMoCWcwx/EUOzyoQ==
   dependencies:
-    "@typescript-eslint/types" "4.27.0"
-    "@typescript-eslint/visitor-keys" "4.27.0"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
+    "@typescript-eslint/types" "5.5.0"
+    "@typescript-eslint/visitor-keys" "5.5.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.27.0":
-  version "4.27.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.27.0.tgz#f56138b993ec822793e7ebcfac6ffdce0a60cb81"
-  integrity sha512-es0GRYNZp0ieckZ938cEANfEhsfHrzuLrePukLKtY3/KPXcq1Xd555Mno9/GOgXhKzn0QfkDLVgqWO3dGY80bg==
+"@typescript-eslint/visitor-keys@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.5.0.tgz#4787586897b61f26068a3db5c50b3f5d254f9083"
+  integrity sha512-4GzJ1kRtsWzHhdM40tv0ZKHNSbkDhF0Woi/TDwVJX6UICwJItvP7ZTXbjTkCdrors7ww0sYe0t+cIKDAJwZ7Kw==
   dependencies:
-    "@typescript-eslint/types" "4.27.0"
-    eslint-visitor-keys "^2.0.0"
+    "@typescript-eslint/types" "5.5.0"
+    eslint-visitor-keys "^3.0.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -1250,15 +1257,15 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
-acorn@^7.4.0:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
 acorn@^8.4.1:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+
+acorn@^8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
+  integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -1304,16 +1311,6 @@ ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.0.tgz#60cc45d9c46a477d80d92c48076d972c342e5720"
-  integrity sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
 ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -1340,6 +1337,11 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -1380,6 +1382,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 array-differ@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
@@ -1394,6 +1401,17 @@ array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
   integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
+
+array-includes@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.4.tgz#f5b493162c760f3539631f005ba2bb46acb45ba9"
+  integrity sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.7"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -1411,6 +1429,15 @@ array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
+
+array.prototype.flat@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz#07e0975d84bbc7c48cd1879d609e682598d33e13"
+  integrity sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -1438,11 +1465,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
-
-astral-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
-  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1843,6 +1865,11 @@ config-chain@^1.1.12:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
+confusing-browser-globals@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
+  integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -2024,10 +2051,31 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
+debug@4, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.3.1, debug@^4.3.2:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
 
@@ -2140,6 +2188,13 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -2296,6 +2351,32 @@ es-abstract@^1.18.0-next.2:
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.1"
 
+es-abstract@^1.19.0, es-abstract@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
+  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    get-symbol-description "^1.0.0"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    internal-slot "^1.0.3"
+    is-callable "^1.2.4"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.1"
+    is-string "^1.0.7"
+    is-weakref "^1.0.1"
+    object-inspect "^1.11.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
+
 es-module-lexer@^0.9.0:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
@@ -2330,6 +2411,75 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-config-airbnb-base@^15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz#6b09add90ac79c2f8d723a2580e07f3925afd236"
+  integrity sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==
+  dependencies:
+    confusing-browser-globals "^1.0.10"
+    object.assign "^4.1.2"
+    object.entries "^1.1.5"
+    semver "^6.3.0"
+
+eslint-config-prettier@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+
+eslint-import-resolver-node@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
+  integrity sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==
+  dependencies:
+    debug "^3.2.7"
+    resolve "^1.20.0"
+
+eslint-import-resolver-typescript@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.5.0.tgz#07661966b272d14ba97f597b51e1a588f9722f0a"
+  integrity sha512-qZ6e5CFr+I7K4VVhQu3M/9xGv9/YmwsEXrsm3nimw8vWaVHRDrQRp26BgCypTxBp3vUp4o5aVEJRiy0F2DFddQ==
+  dependencies:
+    debug "^4.3.1"
+    glob "^7.1.7"
+    is-glob "^4.0.1"
+    resolve "^1.20.0"
+    tsconfig-paths "^3.9.0"
+
+eslint-module-utils@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz#b435001c9f8dd4ab7f6d0efcae4b9696d4c24b7c"
+  integrity sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==
+  dependencies:
+    debug "^3.2.7"
+    find-up "^2.1.0"
+    pkg-dir "^2.0.0"
+
+eslint-plugin-import@^2.25.3:
+  version "2.25.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz#a554b5f66e08fb4f6dc99221866e57cfff824766"
+  integrity sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==
+  dependencies:
+    array-includes "^3.1.4"
+    array.prototype.flat "^1.2.5"
+    debug "^2.6.9"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.6"
+    eslint-module-utils "^2.7.1"
+    has "^1.0.3"
+    is-core-module "^2.8.0"
+    is-glob "^4.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.5"
+    resolve "^1.20.0"
+    tsconfig-paths "^3.11.0"
+
+eslint-plugin-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -2338,12 +2488,13 @@ eslint-scope@5.1.1, eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
-  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+eslint-scope@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.0.tgz#c1f6ea30ac583031f203d65c73e723b01298f153"
+  integrity sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==
   dependencies:
-    eslint-visitor-keys "^1.1.0"
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
 
 eslint-utils@^3.0.0:
   version "3.0.0"
@@ -2352,46 +2503,46 @@ eslint-utils@^3.0.0:
   dependencies:
     eslint-visitor-keys "^2.0.0"
 
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
-  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
-
 eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint@^7.28.0:
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.29.0.tgz#ee2a7648f2e729485e4d0bd6383ec1deabc8b3c0"
-  integrity sha512-82G/JToB9qIy/ArBzIWG9xvvwL3R86AlCjtGw+A29OMZDqhTybz/MByORSukGxeI+YPCR4coYyITKk8BFH9nDA==
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
+  integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
+
+eslint@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.4.0.tgz#2fa01b271cafc28addc2719e551acff5e89f5230"
+  integrity sha512-kv0XQcAQJL/VD9THQKhTQZVqkJKA+tIj/v2ZKNaIHRAADcJWFb+B/BAewUYuF6UVg1s2xC5qXVoDk0G8sKGeTA==
   dependencies:
-    "@babel/code-frame" "7.12.11"
-    "@eslint/eslintrc" "^0.4.2"
+    "@eslint/eslintrc" "^1.0.5"
+    "@humanwhocodes/config-array" "^0.9.2"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
-    debug "^4.0.1"
+    debug "^4.3.2"
     doctrine "^3.0.0"
     enquirer "^2.3.5"
     escape-string-regexp "^4.0.0"
-    eslint-scope "^5.1.1"
-    eslint-utils "^2.1.0"
-    eslint-visitor-keys "^2.0.0"
-    espree "^7.3.1"
+    eslint-scope "^7.1.0"
+    eslint-utils "^3.0.0"
+    eslint-visitor-keys "^3.1.0"
+    espree "^9.2.0"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
     functional-red-black-tree "^1.0.1"
-    glob-parent "^5.1.2"
+    glob-parent "^6.0.1"
     globals "^13.6.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
-    js-yaml "^3.13.1"
+    js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
     lodash.merge "^4.6.2"
@@ -2399,27 +2550,21 @@ eslint@^7.28.0:
     natural-compare "^1.4.0"
     optionator "^0.9.1"
     progress "^2.0.0"
-    regexpp "^3.1.0"
+    regexpp "^3.2.0"
     semver "^7.2.1"
-    strip-ansi "^6.0.0"
+    strip-ansi "^6.0.1"
     strip-json-comments "^3.1.0"
-    table "^6.0.9"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^7.3.0, espree@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
-  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
+espree@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.2.0.tgz#c50814e01611c2d0f8bd4daa83c369eabba80dbc"
+  integrity sha512-oP3utRkynpZWF/F2x/HZJ+AGtnIclaR7z1pYPxy7NYM2fSO6LgK/Rkny8anRSPK/VwEA1eqm2squui0T7ZMOBg==
   dependencies:
-    acorn "^7.4.0"
+    acorn "^8.6.0"
     acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^1.3.0"
-
-esprima@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
-  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+    eslint-visitor-keys "^3.1.0"
 
 esquery@^1.4.0:
   version "1.4.0"
@@ -2504,6 +2649,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-glob@^3.1.1:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
@@ -2579,7 +2729,7 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.0.0:
+find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
@@ -2679,7 +2829,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -2713,6 +2863,14 @@ get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -2770,12 +2928,19 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@^5.1.2:
+glob-parent@^5.1.0, glob-parent@^5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
+
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
@@ -2794,7 +2959,7 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.6:
+glob@^7.0.3, glob@^7.0.6, glob@^7.1.7:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -2813,7 +2978,7 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.2, globby@^11.0.3:
+globby@^11.0.2, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
@@ -2895,6 +3060,13 @@ has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has-unicode@^2.0.0, has-unicode@^2.0.1:
   version "2.0.1"
@@ -3009,6 +3181,11 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+ignore@^5.1.8:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
+  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -3098,6 +3275,15 @@ inquirer@^7.3.3:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+internal-slot@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
+  integrity sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==
+  dependencies:
+    get-intrinsic "^1.1.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
@@ -3135,6 +3321,11 @@ is-callable@^1.1.4, is-callable@^1.2.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
+is-callable@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
+  integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -3146,6 +3337,13 @@ is-core-module@^2.2.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.4.0.tgz#8e9fc8e15027b011418026e98f0e6f4d86305cc1"
   integrity sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
+  integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
   dependencies:
     has "^1.0.3"
 
@@ -3185,6 +3383,13 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -3262,6 +3467,19 @@ is-regex@^1.1.3:
     call-bind "^1.0.2"
     has-symbols "^1.0.2"
 
+is-regex@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
+is-shared-array-buffer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz#97b0c85fbdacb59c9c446fe653b82cf2b5b7cfe6"
+  integrity sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==
+
 is-ssh@^1.3.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/is-ssh/-/is-ssh-1.3.3.tgz#7f133285ccd7f2c2c7fc897b771b53d95a2b2c7e"
@@ -3278,6 +3496,13 @@ is-string@^1.0.5, is-string@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
   integrity sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==
+
+is-string@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.4"
@@ -3302,6 +3527,13 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
+
+is-weakref@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.1.tgz#842dba4ec17fa9ac9850df2d6efbc1737274f2a2"
+  integrity sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==
+  dependencies:
+    call-bind "^1.0.0"
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -3337,13 +3569,12 @@ jest-worker@^27.0.6:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -3365,11 +3596,6 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema-traverse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
-  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
-
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -3384,6 +3610,13 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
 
 json5@^2.1.2:
   version "2.2.0"
@@ -3556,11 +3789,6 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
-
 lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
@@ -3606,17 +3834,12 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash.truncate@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
-  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
-
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3950,12 +4173,17 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0:
+ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -4211,6 +4439,11 @@ object-inspect@^1.10.3, object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
   integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
 
+object-inspect@^1.11.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.1.tgz#d4bd7d7de54b9a75599f59a00bd698c1f1c6549b"
+  integrity sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==
+
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -4226,6 +4459,15 @@ object.assign@^4.1.2:
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
 
+object.entries@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.5.tgz#e1acdd17c4de2cd96d5a08487cfb9db84d881861"
+  integrity sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
+
 object.getownpropertydescriptors@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz#1bd63aeacf0d5d2d2f31b5e393b03a7c601a23f7"
@@ -4234,6 +4476,15 @@ object.getownpropertydescriptors@^2.0.3:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.2"
+
+object.values@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.5.tgz#959f63e3ce9ef108720333082131e4a459b716ac"
+  integrity sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.1"
 
 once@^1.3.0, once@^1.4.0:
   version "1.4.0"
@@ -4596,6 +4847,13 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
+
 pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
@@ -4657,6 +4915,18 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -4924,7 +5194,7 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-regexpp@^3.1.0:
+regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -4966,11 +5236,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
-
-require-from-string@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
-  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -5077,7 +5342,7 @@ schema-utils@^3.0.0, schema-utils@^3.1.0, schema-utils@^3.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0:
+semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -5147,15 +5412,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-slice-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
-  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
 
 slide@^1.1.6:
   version "1.1.6"
@@ -5405,6 +5661,13 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -5475,18 +5738,6 @@ supports-color@^8.0.0:
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
-
-table@^6.0.9:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.7.1.tgz#ee05592b7143831a8c94f3cee6aae4c1ccef33e2"
-  integrity sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==
-  dependencies:
-    ajv "^8.0.1"
-    lodash.clonedeep "^4.5.0"
-    lodash.truncate "^4.4.2"
-    slice-ansi "^4.0.0"
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
 
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
@@ -5645,6 +5896,16 @@ ts-loader@^9.2.3:
     enhanced-resolve "^5.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
+
+tsconfig-paths@^3.11.0, tsconfig-paths@^3.9.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz#19769aca6ee8f6a1a341e38c8fa45dd9fb18899b"
+  integrity sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"


### PR DESCRIPTION
This PR adds configurations for formatting and linting (`eslint`) to the repo. 
Furthermore, it adds`esbenp.prettier-vscode` to the list of recommended extensions for the development of the VSC extension, so the code can be formatted on save.

Closes #5 