### PR TITLE
Wait for LS to show compilation simulation

### DIFF
--- a/keith-vscode/package.json
+++ b/keith-vscode/package.json
@@ -399,12 +399,12 @@
       ],
       "editor/title": [
         {
-          "when": "resourceLangId == sctx || resourceLangId == elkt || resourceLangId == kgt || resourceLangId == kgx || resourceLangId == kviz || resourceLangId == strl || resourceLangId == lus",
+          "when": "keith.vscode:compilationReady && resourceLangId == sctx || keith.vscode:compilationReady && resourceLangId == elkt || keith.vscode:compilationReady && resourceLangId == kgt || keith.vscode:compilationReady && resourceLangId == kgx || keith.vscode:compilationReady && resourceLangId == kviz || keith.vscode:compilationReady && resourceLangId == strl || keith.vscode:compilationReady && resourceLangId == lus",
           "command": "keith-vscode.compile",
           "group": "navigation@1"
         },
         {
-          "when": "resourceLangId == sctx || resourceLangId == elkt || resourceLangId == kgt || resourceLangId == kgx || resourceLangId == kviz || resourceLangId == strl || resourceLangId == lus",
+          "when": "keith.vscode:compilationReady && resourceLangId == sctx || keith.vscode:compilationReady && resourceLangId == elkt || keith.vscode:compilationReady && resourceLangId == kgt || keith.vscode:compilationReady && resourceLangId == kgx || keith.vscode:compilationReady && resourceLangId == kviz || keith.vscode:compilationReady && resourceLangId == strl || keith.vscode:compilationReady && resourceLangId == lus",
           "command": "keith-vscode.simulate",
           "group": "navigation@2"
         },

--- a/keith-vscode/package.json
+++ b/keith-vscode/package.json
@@ -325,9 +325,11 @@
           "when": "false"
         },
         {
+          "when": "keith.vscode:compilationReady && resourceLangId == sctx || keith.vscode:compilationReady && resourceLangId == elkt || keith.vscode:compilationReady && resourceLangId == kgt || keith.vscode:compilationReady && resourceLangId == kgx || keith.vscode:compilationReady && resourceLangId == kviz || keith.vscode:compilationReady && resourceLangId == strl || keith.vscode:compilationReady && resourceLangId == lus",
           "command": "keith-vscode.compile"
         },
         {
+          "when": "keith.vscode:compilationReady && resourceLangId == sctx || keith.vscode:compilationReady && resourceLangId == elkt || keith.vscode:compilationReady && resourceLangId == kgt || keith.vscode:compilationReady && resourceLangId == kgx || keith.vscode:compilationReady && resourceLangId == kviz || keith.vscode:compilationReady && resourceLangId == strl || keith.vscode:compilationReady && resourceLangId == lus",
           "command": "keith-vscode.compile-snapshot"
         },
         {
@@ -355,9 +357,11 @@
           "command": "keith-vscode.compilation-time"
         },
         {
+          "when": "keith.vscode:compilationReady && resourceLangId == sctx || keith.vscode:compilationReady && resourceLangId == elkt || keith.vscode:compilationReady && resourceLangId == kgt || keith.vscode:compilationReady && resourceLangId == kgx || keith.vscode:compilationReady && resourceLangId == kviz || keith.vscode:compilationReady && resourceLangId == strl || keith.vscode:compilationReady && resourceLangId == lus",
           "command": "keith-vscode.simulate"
         },
         {
+          "when": "keith.vscode:compilationReady && resourceLangId == sctx || keith.vscode:compilationReady && resourceLangId == elkt || keith.vscode:compilationReady && resourceLangId == kgt || keith.vscode:compilationReady && resourceLangId == kgx || keith.vscode:compilationReady && resourceLangId == kviz || keith.vscode:compilationReady && resourceLangId == strl || keith.vscode:compilationReady && resourceLangId == lus",
           "command": "keith-vscode.simulate-snapshot"
         },
         {

--- a/keith-vscode/src/kico/compilation-data-provider.ts
+++ b/keith-vscode/src/kico/compilation-data-provider.ts
@@ -219,6 +219,7 @@ export class CompilationDataProvider implements vscode.TreeDataProvider<Compilat
 
         this.context.subscriptions.push(
             vscode.commands.registerCommand(REQUEST_CS.command, async () => {
+                vscode.commands.executeCommand('setContext', 'keith.vscode:compilationReady', false)
                 await this.requestSystemDescriptions()
                 vscode.window.showInformationMessage('Registered compilation system')
             })
@@ -410,6 +411,10 @@ export class CompilationDataProvider implements vscode.TreeDataProvider<Compilat
     handleReceiveSystemDescriptions(systems: CompilationSystem[], snapshotSystems: CompilationSystem[]): void {
         // Remove status bar element after successfully requesting systems
         this.requestSystems.hide()
+
+        // Compilation and simulation menu items
+        vscode.commands.executeCommand('setContext', 'keith.vscode:compilationReady', true)
+
         // Sort all compilation systems by id
         systems.sort((a, b) => (a.id > b.id ? 1 : -1))
         this.systems = systems


### PR DESCRIPTION
 Only show compilation and simulation system menu item (not the command palette) if systems are registered for current editor.

Fixes: #15 